### PR TITLE
Feature/336 improve points edit

### DIFF
--- a/src/app/events/components/grade/grade.component.html
+++ b/src/app/events/components/grade/grade.component.html
@@ -8,6 +8,7 @@
         step="0.01"
         min="0"
         max="{{ maxPoints }}"
+        tabindex="{{ tabIndex }}"
         [formControl]="pointsInput"
         (input)="onChange(pointInput.value)"
       />

--- a/src/app/events/components/grade/grade.component.ts
+++ b/src/app/events/components/grade/grade.component.ts
@@ -30,6 +30,7 @@ import { Student } from '../../../shared/models/student.model';
 export class GradeComponent implements OnInit, OnDestroy {
   @Input() grade: GradeOrNoResult;
   @Input() student: Student;
+  @Input() tabIndex: number;
 
   @Output()
   savePoints = new EventEmitter<TestPointsResult>();

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -150,9 +150,7 @@
             "
             class="grade"
             [ngClass]="
-              selectedTest !== undefined &&
-              (grade.result?.TestId === selectedTest?.Id ||
-                grade.TestId === selectedTest?.Id)
+              selectedTest !== undefined && grade.test.Id === selectedTest?.Id
                 ? 'selected'
                 : ''
             "

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -119,7 +119,12 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let studentGrade of data.studentGrades">
+        <tr
+          *ngFor="
+            let studentGrade of data.studentGrades;
+            trackBy: trackStudentGrade
+          "
+        >
           <td class="primary-column-width sticky">
             <a class="text-body" [routerLink]="'#'">
               {{ studentGrade.student.FullName }}
@@ -137,7 +142,10 @@
             [ngClass]="{ selected: selectedTest === undefined }"
           ></td>
           <td
-            *ngFor="let grade of studentGrade.grades"
+            *ngFor="
+              let grade of studentGrade.grades;
+              trackBy: trackGradeOf(studentGrade.student)
+            "
             class="grade"
             [ngClass]="
               selectedTest !== undefined &&

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -122,6 +122,7 @@
         <tr
           *ngFor="
             let studentGrade of data.studentGrades;
+            let studentGradeIndex = index;
             trackBy: trackStudentGrade
           "
         >
@@ -144,6 +145,7 @@
           <td
             *ngFor="
               let grade of studentGrade.grades;
+              let gradeIndex = index;
               trackBy: trackGradeOf(studentGrade.student)
             "
             class="grade"
@@ -158,6 +160,7 @@
             <erz-grade
               [grade]="grade"
               [student]="studentGrade.student"
+              [tabIndex]="(1 + gradeIndex) * 1000 + studentGradeIndex"
               (savePoints)="savePoints($event)"
             ></erz-grade>
           </td>

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.ts
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Course, TestPointsResult } from 'src/app/shared/models/course.model';
+import { GradeOrNoResult } from 'src/app/shared/models/student-grades';
+import { Student } from 'src/app/shared/models/student.model';
 import { Test } from '../../../shared/models/test.model';
 import {
   Filter,
@@ -30,5 +32,15 @@ export class TestEditGradesComponent implements OnInit {
 
   savePoints(requestBody: TestPointsResult) {
     this.state.savePoints(requestBody);
+  }
+
+  trackStudentGrade(index: number) {
+    return index;
+  }
+
+  trackGradeOf(student: Student) {
+    return function (_: number, grade: GradeOrNoResult) {
+      return `${student.Id}_${grade.test.Id}`;
+    };
   }
 }


### PR DESCRIPTION
Es gab noch drei Unschönheiten bei der Eingabe von Punkten:
- Fokus ging verloren nachdem ein Wert eingegeben wurde - dies kann mit den `trackBy` Properties auf den `ngFor` behoben werden. Für verschachtelte `ngFor`s muss dies für jede Stufe implementiert werden.
- Mit Tab konnte nicht durch die Tabelle navigiert werden - bzw. die Navigation erfolgte pro Zeile, das ist aber meistens nicht was man will - man möchte eher durch die Spalte navigieren können. 
- In der Mobile View wurde das Eingebafeld nicht angzeigt, wenn noch kein Resultat existiert - v.a. weil der boolsche Vergleich einen Fehler enthielt - das fixen/ vereinfachen des Ausdrucks hat dann auch gleich das Problem behoben.