### PR TITLE
Feature/333 bugfixes

### DIFF
--- a/.github/workflows/buildDeploy.yml
+++ b/.github/workflows/buildDeploy.yml
@@ -3,8 +3,8 @@ name: build 🏭 deploy 🚀
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  #pull_request:
+    #branches: [ master ]
 
 jobs:
   build:

--- a/src/app/events/components/grade/grade.component.html
+++ b/src/app/events/components/grade/grade.component.html
@@ -18,7 +18,7 @@
       [options]="gradeOptions"
       [allowEmpty]="grade.kind === 'no-result'"
       [value]="grade.kind === 'grade' ? grade.result.GradeId : null"
-      [disabled]="!isGradingScaleEnabled"
+      [disabled]="gradingScaleDisabled$ | async"
       [tabindex]="tabIndex"
       (valueChange)="onGradeChange($event)"
       class="grade-select"

--- a/src/app/events/components/grade/grade.component.html
+++ b/src/app/events/components/grade/grade.component.html
@@ -19,6 +19,7 @@
       [allowEmpty]="grade.kind === 'no-result'"
       [value]="grade.kind === 'grade' ? grade.result.GradeId : null"
       [disabled]="!isGradingScaleEnabled"
+      [tabindex]="tabIndex"
       (valueChange)="onGradeChange($event)"
       class="grade-select"
       data-testid="grade-select"

--- a/src/app/events/components/grade/grade.component.spec.ts
+++ b/src/app/events/components/grade/grade.component.spec.ts
@@ -228,7 +228,9 @@ describe('GradeComponent', () => {
       component.grade = grade;
       fixture.detectChanges();
 
-      expect(component.isGradingScaleEnabled).toBe(false);
+      component.gradingScaleDisabled$.subscribe((result) =>
+        expect(result).toBe(true)
+      );
     });
 
     it('should enable gradingScale when result does not have points', () => {
@@ -240,7 +242,9 @@ describe('GradeComponent', () => {
       // when
       fixture.detectChanges();
 
-      expect(component.isGradingScaleEnabled).toBe(true);
+      component.gradingScaleDisabled$.subscribe((result) =>
+        expect(result).toBe(false)
+      );
     });
 
     it('should enable gradingScale when input is changed to empty', () => {
@@ -255,7 +259,9 @@ describe('GradeComponent', () => {
       component.onPointsChange('');
 
       // then
-      expect(component.isGradingScaleEnabled).toBe(true);
+      component.gradingScaleDisabled$.subscribe((result) =>
+        expect(result).toBe(false)
+      );
     });
 
     it('should enable gradingScale when test is not point grading', () => {
@@ -269,7 +275,9 @@ describe('GradeComponent', () => {
       fixture.detectChanges();
 
       // then
-      expect(component.isGradingScaleEnabled).toBe(true);
+      component.gradingScaleDisabled$.subscribe((result) =>
+        expect(result).toBe(false)
+      );
     });
   });
 });

--- a/src/app/events/components/grade/grade.component.spec.ts
+++ b/src/app/events/components/grade/grade.component.spec.ts
@@ -293,14 +293,3 @@ function expectValidationErrorMessage(debugElement: DebugElement) {
 
   expect(error.textContent).toContain('global.validation-errors.invalidPoints');
 }
-
-function expectOptions(select: HTMLSelectElement) {
-  expect(select.options.length).toBe(6);
-  const options = select.options!;
-  expect(options[0]?.textContent?.trim()).toBe('1.0');
-  expect(options[1]?.textContent?.trim()).toBe('2.0');
-  expect(options[2]?.textContent?.trim()).toBe('3.0');
-  expect(options[3]?.textContent?.trim()).toBe('4.0');
-  expect(options[4]?.textContent?.trim()).toBe('5.0');
-  expect(options[5]?.textContent?.trim()).toBe('6.0');
-}

--- a/src/app/events/components/grade/grade.component.ts
+++ b/src/app/events/components/grade/grade.component.ts
@@ -53,11 +53,11 @@ export class GradeComponent implements OnInit, OnDestroy {
 
   private pointsSubject$: Subject<string> = new Subject<string>();
   private gradeSubject$: Subject<number> = new Subject<number>();
-  private _gradingScaleDisabled$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
+  private gradingScaleDisabledSubject$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(
     true
   );
 
-  gradingScaleDisabled$ = this._gradingScaleDisabled$.asObservable();
+  gradingScaleDisabled$ = this.gradingScaleDisabledSubject$.asObservable();
 
   points$: Observable<number> = this.pointsSubject$.pipe(
     debounceTime(DEBOUNCE_TIME),
@@ -77,7 +77,7 @@ export class GradeComponent implements OnInit, OnDestroy {
     if (this.grade.kind === 'grade') {
       this.pointsInput.setValue(this.grade.result.Points);
     }
-    this._gradingScaleDisabled$.next(this.disableGradingScale());
+    this.gradingScaleDisabledSubject$.next(this.disableGradingScale());
 
     this.maxPoints = toMaxPoints(this.grade);
     this.points$
@@ -101,7 +101,7 @@ export class GradeComponent implements OnInit, OnDestroy {
 
   onPointsChange(points: string) {
     this.pointsSubject$.next(points);
-    this._gradingScaleDisabled$.next(points.length > 0);
+    this.gradingScaleDisabledSubject$.next(points.length > 0);
   }
 
   onGradeChange(gradeId: number) {

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
@@ -118,6 +118,6 @@ table th {
   }
 
   table .sticky.sticky-col-3 {
-    left: 400px;
+    left: 452px;
   }
 }

--- a/src/app/events/components/tests-header/tests-header.component.html
+++ b/src/app/events/components/tests-header/tests-header.component.html
@@ -7,7 +7,9 @@
     <div class="d-flex">
       <i class="material-icons btn">navigate_before</i>
       <div class="text-justify">
-        <div>{{ course.Designation }}</div>
+        <div>
+          {{ getDesignation() }}
+        </div>
         <div class="font-color-light-gray" *ngIf="course.ParticipatingStudents">
           {{
             (course.ParticipatingStudents.length === 1

--- a/src/app/events/components/tests-header/tests-header.component.ts
+++ b/src/app/events/components/tests-header/tests-header.component.ts
@@ -15,4 +15,12 @@ export class TestsHeaderComponent {
   loadReportUrl(): string {
     return this.reportsService.getEventReportUrl(this.course.Id);
   }
+
+  getDesignation() {
+    return this.course.Designation + this.getClassDesignation();
+  }
+
+  private getClassDesignation() {
+    return this.course.Classes ? `, ${this.course.Classes[0].Designation}` : '';
+  }
 }

--- a/src/app/shared/components/select/select.component.html
+++ b/src/app/shared/components/select/select.component.html
@@ -1,5 +1,6 @@
 <select
   class="form-control"
+  tabindex="{{ tabindex }}"
   [disabled]="disabled"
   [ngModel]="value$ | async"
   (ngModelChange)="valueChange.emit($event && $event.Key)"

--- a/src/app/shared/components/select/select.component.ts
+++ b/src/app/shared/components/select/select.component.ts
@@ -10,6 +10,7 @@ import {
 import { DropDownItem } from '../../models/drop-down-item.model';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { number } from 'fp-ts';
 
 @Component({
   selector: 'erz-select',
@@ -22,6 +23,7 @@ export class SelectComponent implements OnChanges {
   @Input() emptyLabel: string = '';
   @Input() value: Option<number> = null;
   @Input() disabled: boolean = false;
+  @Input() tabindex: number = 0;
   @Output() valueChange = new EventEmitter<Option<number>>();
 
   options$ = new BehaviorSubject<ReadonlyArray<DropDownItem>>([]);

--- a/src/app/shared/models/course.model.ts
+++ b/src/app/shared/models/course.model.ts
@@ -1,8 +1,8 @@
 import * as t from 'io-ts';
-import { LocalDateTimeFromString, Maybe, Option } from './common-types';
+import { LocalDateTimeFromString, Option } from './common-types';
+import { Student } from './student.model';
 import { StudyClass } from './study-class.model';
 import { Result, Test } from './test.model';
-import { Student } from './student.model';
 
 const id = t.type({
   Id: t.number,
@@ -37,10 +37,7 @@ const ExpandedAttendanceRef = t.partial({
 const AttendanceRef = t.intersection([id, HRef, ExpandedAttendanceRef]);
 
 const Grading = t.type({
-  // the property AverageGrade was renamed to AverageTestResult with a recent backend hotfix -
-  // change the property name when the hotfix reaches the development backend
-  AverageTestResult: Maybe(t.number),
-  AverageGrade: Maybe(t.number),
+  AverageTestResult: t.number,
   CanGrade: t.boolean,
   EventDesignation: t.string,
   EventId: t.number,

--- a/src/app/shared/models/student-grades.ts
+++ b/src/app/shared/models/student-grades.ts
@@ -78,7 +78,7 @@ function getFinalGrade(student: Student, gradings: Grading[]): FinalGrade {
 
   return {
     id: grading?.Id,
-    average: grading?.AverageTestResult,
+    average: toAverage(grading),
     finalGradeId: grading?.GradeId,
     canGrade: grading?.CanGrade || false,
   };

--- a/src/app/shared/models/student-grades.ts
+++ b/src/app/shared/models/student-grades.ts
@@ -1,4 +1,3 @@
-import { boolean } from 'fp-ts';
 import { Student } from 'src/app/shared/models/student.model';
 import { Result, Test } from 'src/app/shared/models/test.model';
 import { Sorting } from '../services/sort.service';
@@ -83,6 +82,12 @@ function getFinalGrade(student: Student, gradings: Grading[]): FinalGrade {
     finalGradeId: grading?.GradeId,
     canGrade: grading?.CanGrade || false,
   };
+}
+
+function toAverage(grading: Grading | undefined) {
+  if (grading === undefined) return null;
+  if (grading.AverageTestResult === 0) return null;
+  return grading!.AverageTestResult;
 }
 
 export const compareFn = ({ key, ascending }: Sorting<SortKeys>) => (

--- a/src/app/shared/models/student-grades.ts
+++ b/src/app/shared/models/student-grades.ts
@@ -78,7 +78,7 @@ function getFinalGrade(student: Student, gradings: Grading[]): FinalGrade {
 
   return {
     id: grading?.Id,
-    average: grading?.AverageGrade || grading?.AverageTestResult,
+    average: grading?.AverageTestResult,
     finalGradeId: grading?.GradeId,
     canGrade: grading?.CanGrade || false,
   };

--- a/src/app/shared/services/courses-rest.service.spec.ts
+++ b/src/app/shared/services/courses-rest.service.spec.ts
@@ -45,7 +45,7 @@ describe('CoursesRestService', () => {
   describe('getExpandedCourse', () => {
     const id = 9248;
     const mockCourse = buildCourse(id);
-    it('should request a single course by ID expanding ParticipatingStudents, EvaluationStatusRef, Tests, Gradings, FinalGrades', () => {
+    it('should request a single course by ID expanding ParticipatingStudents, EvaluationStatusRef, Tests, Gradings, FinalGrades, Classes', () => {
       service.getExpandedCourse(id).subscribe((result) => {
         expect(result).toEqual(mockCourse);
       });
@@ -54,7 +54,7 @@ describe('CoursesRestService', () => {
         .expectOne(
           (req) =>
             req.url ===
-            `https://eventotest.api/Courses/${id}?expand=ParticipatingStudents,EvaluationStatusRef,Tests,Gradings,FinalGrades`
+            `https://eventotest.api/Courses/${id}?expand=ParticipatingStudents,EvaluationStatusRef,Tests,Gradings,FinalGrades,Classes`
         )
         .flush(Course.encode(mockCourse));
     });

--- a/src/app/shared/services/courses-rest.service.ts
+++ b/src/app/shared/services/courses-rest.service.ts
@@ -31,7 +31,7 @@ export class CoursesRestService extends RestService<typeof Course> {
   getExpandedCourse(courseId: number): Observable<Course> {
     return this.http
       .get<unknown>(
-        `${this.baseUrl}/${courseId}?expand=ParticipatingStudents,EvaluationStatusRef,Tests,Gradings,FinalGrades`
+        `${this.baseUrl}/${courseId}?expand=ParticipatingStudents,EvaluationStatusRef,Tests,Gradings,FinalGrades,Classes`
       )
       .pipe(switchMap(decode(Course)));
   }

--- a/src/spec-builders.ts
+++ b/src/spec-builders.ts
@@ -512,7 +512,6 @@ export function buildGrading(
 ): Grading {
   return {
     AverageTestResult: averageGrade,
-    AverageGrade: averageGrade,
     CanGrade: false,
     EventDesignation: 'Französisch-S2',
     EventId: 9248,


### PR DESCRIPTION
Die am Daily besprochenen Bugfixes und eine kleine Anpassung:
- [x] Klasse fehlt im Header (Seite Testübersicht)
- [x] Mittelwerte sollten nie "0" sein - ich habe jetzt einfach den Wert ganz weg gelassen - als Vorschlag
- [x] Tab funktioniert jetzt auch für die Dropdown - interessanterweise kann man zwei Elementen den gleichen Tabindex geben, dann springt es vom 1ten zum 2ten - und weil Dropdowns die disabled sind übersprungen werden, funktionert alles tiptop.
- [x] Beim Scrollen seitwärts ändert sich die 3. Spalte jetzt nicht mehr - allerdings ist die gesamte Umsetzung etwas fragil - vielleicht hat @hupf noch eine Idee wie man das besser machen könnte

Nicht umgesetzt ist das "Problem", dass man die Note nicht löschen kann, weil das Backend das offenbar gar nicht zulässt - bzw. Sandro ist das noch am abklären - ich habe eine Story geschrieben und ans Board gehängt.

Zusätzlich habe ich noch folgende Anpassungen gemacht:
- der Disabled State des Dropdowns ist jetzt über ein Subject/ Observable gelöst
- Das Todo in course.model.ts konnte ich erledigen
- Damit nicht zuviele Requests abgesetzt werden, wenn man im Dropdown eine Note per Tastatur auswählt, ohne das Dropdown an sich zu öffnen habe ich da auch noch ein Debouncing eingeführt.