### PR TITLE
Feature/338 overwrite final grade

### DIFF
--- a/src/app/events/components/grades/grade-select/grade-select.component.html
+++ b/src/app/events/components/grades/grade-select/grade-select.component.html
@@ -2,6 +2,7 @@
   [options]="options"
   [allowEmpty]="true"
   [value]="selectedGradeId"
+  [disabled]="disabled"
   (valueChange)="onGradeChange($event)"
   data-testid="grade-select"
 >

--- a/src/app/events/components/grades/grade-select/grade-select.component.html
+++ b/src/app/events/components/grades/grade-select/grade-select.component.html
@@ -1,7 +1,7 @@
 <erz-select
   [options]="options"
   [allowEmpty]="true"
-  [value]="selectedGradeId"
+  [value]="valueId"
   [disabled]="disabled"
   (valueChange)="onGradeChange($event)"
   data-testid="grade-select"

--- a/src/app/events/components/grades/grade-select/grade-select.component.html
+++ b/src/app/events/components/grades/grade-select/grade-select.component.html
@@ -1,7 +1,7 @@
 <erz-select
   [options]="options"
   [allowEmpty]="true"
-  [value]="gradeId"
+  [value]="selectedGradeId"
   (valueChange)="onGradeChange($event)"
   data-testid="grade-select"
 >

--- a/src/app/events/components/grades/grade-select/grade-select.component.ts
+++ b/src/app/events/components/grades/grade-select/grade-select.component.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { number } from 'io-ts';
 import { DropDownItem } from 'src/app/shared/models/drop-down-item.model';
+import { FinalGrade } from 'src/app/shared/models/student-grades';
 
 @Component({
   selector: 'erz-grade-select',
@@ -8,13 +10,18 @@ import { DropDownItem } from 'src/app/shared/models/drop-down-item.model';
 })
 export class GradeSelectComponent {
   @Input() options: DropDownItem[];
-  @Input() gradeId: Option<number>;
+  @Input() selectedGradeId: Option<number>; // the selected grade - id from gradingscale
+  @Input() gradeId: Option<number>; // the id of the grade itself
 
-  @Output() selectedGradeId = new EventEmitter<number>();
+  @Output() gradeIdSelected = new EventEmitter<{
+    id: number;
+    selectedGradeId: number;
+  }>();
 
   constructor() {}
 
-  onGradeChange(gradeId: number): void {
-    this.selectedGradeId.emit(gradeId);
+  onGradeChange(selectedGradeId: number): void {
+    if (this.gradeId?.valueOf() === undefined) return;
+    this.gradeIdSelected.emit({ id: this.gradeId?.valueOf(), selectedGradeId });
   }
 }

--- a/src/app/events/components/grades/grade-select/grade-select.component.ts
+++ b/src/app/events/components/grades/grade-select/grade-select.component.ts
@@ -1,7 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { number } from 'io-ts';
 import { DropDownItem } from 'src/app/shared/models/drop-down-item.model';
-import { FinalGrade } from 'src/app/shared/models/student-grades';
 
 @Component({
   selector: 'erz-grade-select',

--- a/src/app/events/components/grades/grade-select/grade-select.component.ts
+++ b/src/app/events/components/grades/grade-select/grade-select.component.ts
@@ -8,7 +8,7 @@ import { DropDownItem } from 'src/app/shared/models/drop-down-item.model';
 })
 export class GradeSelectComponent {
   @Input() options: DropDownItem[];
-  @Input() selectedGradeId: Option<number>; // the selected grade - id from gradingscale
+  @Input() valueId: Option<number>; // the selected key from the options list
   @Input() gradeId: Option<number>; // the id of the grade itself
   @Input() disabled: boolean = false;
 

--- a/src/app/events/components/grades/grade-select/grade-select.component.ts
+++ b/src/app/events/components/grades/grade-select/grade-select.component.ts
@@ -10,6 +10,7 @@ export class GradeSelectComponent {
   @Input() options: DropDownItem[];
   @Input() selectedGradeId: Option<number>; // the selected grade - id from gradingscale
   @Input() gradeId: Option<number>; // the id of the grade itself
+  @Input() disabled: boolean = false;
 
   @Output() gradeIdSelected = new EventEmitter<{
     id: number;

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -149,6 +149,7 @@
               [options]="state.gradingOptionsForCourse$() | async"
               [selectedGradeId]="studentGrade.finalGrade.finalGradeId"
               [gradeId]="studentGrade.finalGrade.id"
+              (gradeIdSelected)="state.overwriteFinalGrade($event)"
             ></erz-grade-select>
           </td>
           <td

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -147,7 +147,7 @@
           >
             <erz-grade-select
               [options]="state.gradingOptionsForCourse$() | async"
-              [selectedGradeId]="studentGrade.finalGrade.finalGradeId"
+              [valueId]="studentGrade.finalGrade.finalGradeId"
               [gradeId]="studentGrade.finalGrade.id"
               [disabled]="!studentGrade.finalGrade.canGrade"
               (gradeIdSelected)="state.overwriteFinalGrade($event)"

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -149,6 +149,7 @@
               [options]="state.gradingOptionsForCourse$() | async"
               [selectedGradeId]="studentGrade.finalGrade.finalGradeId"
               [gradeId]="studentGrade.finalGrade.id"
+              [disabled]="!studentGrade.finalGrade.canGrade"
               (gradeIdSelected)="state.overwriteFinalGrade($event)"
             ></erz-grade-select>
           </td>

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -147,7 +147,8 @@
           >
             <erz-grade-select
               [options]="state.gradingOptionsForCourse$() | async"
-              [gradeId]="studentGrade.finalGrade.finalGradeId"
+              [selectedGradeId]="studentGrade.finalGrade.finalGradeId"
+              [gradeId]="studentGrade.finalGrade.id"
             ></erz-grade-select>
           </td>
           <td

--- a/src/app/events/services/test-edit-grades-state.service.ts
+++ b/src/app/events/services/test-edit-grades-state.service.ts
@@ -208,9 +208,9 @@ export class TestEditGradesStateService {
     id: number;
     selectedGradeId: number;
   }) {
-    this.gradingsRestService
-      .updateGrade(id, selectedGradeId)
-      .subscribe(console.log);
+    this.gradingsRestService.updateGrade(id, selectedGradeId).subscribe(() => {
+      // do nothing for now...
+    });
   }
 
   private updateStudentGrades(newGrades: UpdatedTestResultResponse) {

--- a/src/app/events/services/test-edit-grades-state.service.ts
+++ b/src/app/events/services/test-edit-grades-state.service.ts
@@ -29,6 +29,7 @@ import { CoursesRestService } from '../../shared/services/courses-rest.service';
 import { GradingScalesRestService } from '../../shared/services/grading-scales-rest.service';
 import { replaceResult, toggleIsPublished } from '../utils/tests';
 import { take } from 'rxjs/operators';
+import { GradingsRestService } from 'src/app/shared/services/gradings-rest.service';
 
 export type Filter = 'all-tests' | 'my-tests';
 
@@ -150,7 +151,8 @@ export class TestEditGradesStateService {
   constructor(
     private sortService: SortService<SortKeys>,
     private courseRestService: CoursesRestService,
-    private gradingScalesRestService: GradingScalesRestService
+    private gradingScalesRestService: GradingScalesRestService,
+    private gradingsRestService: GradingsRestService
   ) {}
 
   setTests(tests: Test[]): void {
@@ -197,6 +199,18 @@ export class TestEditGradesStateService {
     this.courseRestService
       .unpublishTest(test.Id)
       .subscribe(this.toggleTestPublishedState.bind(this));
+  }
+
+  overwriteFinalGrade({
+    id,
+    selectedGradeId,
+  }: {
+    id: number;
+    selectedGradeId: number;
+  }) {
+    this.gradingsRestService
+      .updateGrade(id, selectedGradeId)
+      .subscribe(console.log);
   }
 
   private updateStudentGrades(newGrades: UpdatedTestResultResponse) {

--- a/src/app/shared/models/student-grades.spec.ts
+++ b/src/app/shared/models/student-grades.spec.ts
@@ -41,6 +41,8 @@ describe('StudentGradesService', () => {
 
     expect(results[0].student).toEqual(course.ParticipatingStudents[0]);
     expect(results[1].student).toEqual(course.ParticipatingStudents[1]);
+    expect(results[0].finalGrade.id).toBe(126885);
+    expect(results[1].finalGrade.id).toBe(126885);
     expect(results[0].finalGrade.average).toBe(2.275);
     expect(results[1].finalGrade.average).toBe(2.275);
     expect(results[0].finalGrade.finalGradeId).toBe(3);

--- a/src/app/shared/models/student-grades.spec.ts
+++ b/src/app/shared/models/student-grades.spec.ts
@@ -151,6 +151,8 @@ describe('StudentGradesService', () => {
     expect(results[1].finalGrade.average).toBeUndefined;
     expect(results[0].finalGrade.finalGradeId).toBe(3);
     expect(results[1].finalGrade.finalGradeId).toBeUndefined;
+    expect(results[0].finalGrade.canGrade).toBe(false);
+    expect(results[1].finalGrade.canGrade).toBe(false);
   });
 
   it('should fill up holes with missing grades as no-result', () => {

--- a/src/app/shared/models/student-grades.ts
+++ b/src/app/shared/models/student-grades.ts
@@ -1,3 +1,4 @@
+import { boolean } from 'fp-ts';
 import { Student } from 'src/app/shared/models/student.model';
 import { Result, Test } from 'src/app/shared/models/test.model';
 import { Sorting } from '../services/sort.service';
@@ -13,6 +14,7 @@ export type FinalGrade = {
   id: Maybe<number>;
   average: Maybe<number>;
   finalGradeId: Maybe<number>;
+  canGrade: boolean;
 };
 
 export type Grade = {
@@ -79,6 +81,7 @@ function getFinalGrade(student: Student, gradings: Grading[]): FinalGrade {
     id: grading?.Id,
     average: grading?.AverageGrade || grading?.AverageTestResult,
     finalGradeId: grading?.GradeId,
+    canGrade: grading?.CanGrade || false,
   };
 }
 

--- a/src/app/shared/models/student-grades.ts
+++ b/src/app/shared/models/student-grades.ts
@@ -9,7 +9,8 @@ export type StudentGrade = {
   grades: GradeOrNoResult[];
 };
 
-type FinalGrade = {
+export type FinalGrade = {
+  id: Maybe<number>;
   average: Maybe<number>;
   finalGradeId: Maybe<number>;
 };
@@ -75,6 +76,7 @@ function getFinalGrade(student: Student, gradings: Grading[]): FinalGrade {
   );
 
   return {
+    id: grading?.Id,
     average: grading?.AverageGrade || grading?.AverageTestResult,
     finalGradeId: grading?.GradeId,
   };

--- a/src/app/shared/services/gradings-rest.service.spec.ts
+++ b/src/app/shared/services/gradings-rest.service.spec.ts
@@ -21,22 +21,22 @@ describe('GradingsRestService', () => {
 
   it('should update final grade and return grade id', () => {
     // given
-    const id = 123;
-    const value = 4.5;
+    const gradeId = 123;
+    const selectedGradeId = 5555;
 
     // when
     service
-      .updateGrade(id, value)
-      .subscribe((result) => expect(result).toEqual(id));
+      .updateGrade(gradeId, selectedGradeId)
+      .subscribe((result) => expect(result).toEqual(gradeId));
 
     // then
     httpTestingController
       .expectOne(
         ({ method, url, body }) =>
           method === 'PUT' &&
-          url === `https://eventotest.api/Gradings/${id}` &&
-          isEqual(body, { IdGrade: 123, GradeValue: 4.5 })
+          url === `https://eventotest.api/Gradings/${gradeId}` &&
+          isEqual(body, { IdGrade: selectedGradeId, GradeValue: null })
       )
-      .flush(id);
+      .flush(gradeId);
   });
 });

--- a/src/app/shared/services/gradings-rest.service.spec.ts
+++ b/src/app/shared/services/gradings-rest.service.spec.ts
@@ -35,7 +35,7 @@ describe('GradingsRestService', () => {
         ({ method, url, body }) =>
           method === 'PUT' &&
           url === `https://eventotest.api/Gradings/${gradeId}` &&
-          isEqual(body, { IdGrade: selectedGradeId, GradeValue: null })
+          isEqual(body, { GradeId: selectedGradeId })
       )
       .flush(gradeId);
   });

--- a/src/app/shared/services/gradings-rest.service.spec.ts
+++ b/src/app/shared/services/gradings-rest.service.spec.ts
@@ -1,0 +1,42 @@
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import isEqual from 'lodash-es/isEqual';
+import { buildTestModuleMetadata } from 'src/spec-helpers';
+
+import { GradingsRestService } from './gradings-rest.service';
+
+describe('GradingsRestService', () => {
+  let service: GradingsRestService;
+
+  let httpTestingController: HttpTestingController;
+  beforeEach(() => {
+    TestBed.configureTestingModule(buildTestModuleMetadata({}));
+    service = TestBed.inject(GradingsRestService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should update final grade and return grade id', () => {
+    // given
+    const id = 123;
+    const value = 4.5;
+
+    // when
+    service
+      .updateGrade(id, value)
+      .subscribe((result) => expect(result).toEqual(id));
+
+    // then
+    httpTestingController
+      .expectOne(
+        ({ method, url, body }) =>
+          method === 'PUT' &&
+          url === `https://eventotest.api/Gradings/${id}` &&
+          isEqual(body, { IdGrade: 123, GradeValue: 4.5 })
+      )
+      .flush(id);
+  });
+});

--- a/src/app/shared/services/gradings-rest.service.ts
+++ b/src/app/shared/services/gradings-rest.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { number } from 'fp-ts';
-import { mapTo, Observable, of } from 'rxjs';
+import { mapTo, Observable } from 'rxjs';
 import { Settings, SETTINGS } from 'src/app/settings';
 import { Grading } from '../models/course.model';
 import { RestService } from './rest.service';
@@ -14,13 +13,16 @@ export class GradingsRestService extends RestService<typeof Grading> {
     super(http, settings, Grading, 'Gradings');
   }
 
-  updateGrade(id: number, value: number): Observable<number> {
+  updateGrade(
+    finaleGradeId: number,
+    selectedGradeId: number
+  ): Observable<number> {
     return this.http
-      .put(`${this.baseUrl}/${id}`, this.createBody(id, value))
-      .pipe(mapTo(id));
+      .put(`${this.baseUrl}/${finaleGradeId}`, this.createBody(selectedGradeId))
+      .pipe(mapTo(finaleGradeId));
   }
 
-  private createBody(id: number, value: number) {
-    return { IdGrade: id, GradeValue: value };
+  private createBody(id: number) {
+    return { IdGrade: id, GradeValue: null };
   }
 }

--- a/src/app/shared/services/gradings-rest.service.ts
+++ b/src/app/shared/services/gradings-rest.service.ts
@@ -18,11 +18,7 @@ export class GradingsRestService extends RestService<typeof Grading> {
     selectedGradeId: number
   ): Observable<number> {
     return this.http
-      .put(`${this.baseUrl}/${finaleGradeId}`, this.createBody(selectedGradeId))
+      .put(`${this.baseUrl}/${finaleGradeId}`, { GradeId: selectedGradeId })
       .pipe(mapTo(finaleGradeId));
-  }
-
-  private createBody(id: number) {
-    return { IdGrade: id, GradeValue: null };
   }
 }

--- a/src/app/shared/services/gradings-rest.service.ts
+++ b/src/app/shared/services/gradings-rest.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { number } from 'fp-ts';
+import { mapTo, Observable, of } from 'rxjs';
+import { Settings, SETTINGS } from 'src/app/settings';
+import { Grading } from '../models/course.model';
+import { RestService } from './rest.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GradingsRestService extends RestService<typeof Grading> {
+  constructor(http: HttpClient, @Inject(SETTINGS) settings: Settings) {
+    super(http, settings, Grading, 'Gradings');
+  }
+
+  updateGrade(id: number, value: number): Observable<number> {
+    return this.http
+      .put(`${this.baseUrl}/${id}`, this.createBody(id, value))
+      .pipe(mapTo(id));
+  }
+
+  private createBody(id: number, value: number) {
+    return { IdGrade: id, GradeValue: value };
+  }
+}


### PR DESCRIPTION
Überschreiben eines Final Grades in der Testübersicht - dies ist nur möglich für Kurse im korrekten Status - auf der Testumgebung ist dies aktuell  der Fall für: `#/events/9365/tests`

~~Sobald der Button zum Übernehmen der Mittelwerte umgesetzt ist, können wir auch die DropDowns disablen, wenn der Status noch nicht korrekt ist (dies liegt noch auf einem anderen Branch)~~
Das Property `CanGrade` eines Gradings entscheidet, ob man eine Note setzen kann oder nicht.