### PR TITLE
Bugfixes: Finale Note in Mobile View

### DIFF
--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -193,9 +193,18 @@
           <td class="sticky">
             <div class="d-flex flex-column">
               <div>{{ 'tests.average' | translate }}</div>
+              <div class="mobile mean">
+                {{ 'tests.mean' | translate }}:
+                {{
+                  state.meanOfStudentGradesForCourse$ | async | number: '1.0-3'
+                }}
+              </div>
             </div>
           </td>
-          <td class="desktop sticky sticky sticky-col-2">
+          <td
+            class="desktop sticky sticky sticky-col-2"
+            [ngClass]="{ selected: selectedTest === undefined }"
+          >
             {{ state.meanOfFinalGradesForCourse$ | async | number: '1.0-3' }}
           </td>
           <td class="desktop border-right sticky sticky-col-3">

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -95,7 +95,6 @@
           <th
             class="secondary-column-width border-right sticky sticky-col-3 desktop"
             (click)="state.sortBy('TestsMean')"
-            [ngClass]="{ selected: selectedTest === undefined }"
           >
             <div class="d-flex">
               <div class="column-title">
@@ -164,10 +163,7 @@
               (gradeIdSelected)="state.overwriteFinalGrade($event)"
             ></erz-grade-select>
           </td>
-          <td
-            class="grade border-right sticky sticky-col-3"
-            [ngClass]="{ selected: selectedTest === undefined }"
-          >
+          <td class="grade border-right sticky sticky-col-3">
             {{ studentGrade.finalGrade.average | number: '1.0-3' }}
           </td>
           <td
@@ -192,6 +188,7 @@
             ></erz-grade>
           </td>
         </tr>
+        <!-- course and test averages -->
         <tr>
           <td class="sticky">
             <div class="d-flex flex-column">

--- a/src/app/events/components/tests-list/tests-list.component.ts
+++ b/src/app/events/components/tests-list/tests-list.component.ts
@@ -26,7 +26,10 @@ export class TestsListComponent {
 
   selectedTestId$ = merge(
     this.selectTest$,
-    this.state.tests$.pipe(map((tests) => tests[0]?.Id))
+    this.state.tests$.pipe(
+      take(1),
+      map((tests) => tests[0]?.Id)
+    )
   ).pipe(distinctUntilChanged());
 
   selectedTest$: Observable<Test | undefined> = this.selectedTestId$.pipe(


### PR DESCRIPTION
dieser PR bezieht sich auf Punkt/ Bild 5 in diesem Kommentar hier: https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/333#issuecomment-1133041285

Wenn in der Mobilen Ansicht im Dropdown die Option "Note" ausgewählt wird, dann:
- soll der Mittelwert für den Schüler nur unterhalb des Namens angezeigt werden - die extra Spalte braucht es nicht, diese ist nur in der Desktop ansicht sichtbar
- Der Mittelwert für Alle Schüler über alle Tests wird unterhalb des Labels "Durchschnitt" angezeigt - in der Desktop View gibt es dafür ebenfalls eine Spalte (Dieser Punkt wurde nicht erwähnt im oben verlinkten Kommentar - aber ws war bisher trotzdem falsch)
- Der graue Strich ist jetzt durchgezogen (hängt damit zusammen, dass die Spalte nicht mehr angezeigt wird)
- Beim Testen ist mir noch aufgefallen, dass wenn man in der Mobile View die Optione "Note" gewählt hat und dann eine Finale Note erfasst - dass im Dropdown dann wieder auf den initial ausgewählten Test gewechselt wird. Das habe ich geflickt und die Selektion ändert nicht mehr.