### PR TITLE
Feature/403 delete gradings

### DIFF
--- a/src/app/events/components/grade/grade.component.html
+++ b/src/app/events/components/grade/grade.component.html
@@ -28,7 +28,7 @@
     </div>
     <erz-select
       [options]="gradeOptions"
-      [allowEmpty]="grade.kind === 'no-result'"
+      [allowEmpty]="true"
       [value]="grade.kind === 'grade' ? grade.result.GradeId : null"
       [disabled]="gradingScaleDisabled$ | async"
       [tabindex]="tabIndex"

--- a/src/app/events/components/grade/grade.component.spec.ts
+++ b/src/app/events/components/grade/grade.component.spec.ts
@@ -86,16 +86,17 @@ describe('GradeComponent', () => {
       const select = debugElement.query(byTestId('grade-select')).nativeElement
         .firstChild;
 
-      expect(select.options.length).toBe(6);
-      expect(select.options[0].textContent?.trim()).toBe('1.0');
-      expect(select.options[1].textContent?.trim()).toBe('2.0');
-      expect(select.options[2].textContent?.trim()).toBe('3.0');
-      expect(select.options[3].textContent?.trim()).toBe('4.0');
-      expect(select.options[4].textContent?.trim()).toBe('5.0');
-      expect(select.options[5].textContent?.trim()).toBe('6.0');
+      expect(select.options.length).toBe(7);
+      expect(select.options[0].textContent?.trim()).toBe('');
+      expect(select.options[1].textContent?.trim()).toBe('1.0');
+      expect(select.options[2].textContent?.trim()).toBe('2.0');
+      expect(select.options[3].textContent?.trim()).toBe('3.0');
+      expect(select.options[4].textContent?.trim()).toBe('4.0');
+      expect(select.options[5].textContent?.trim()).toBe('5.0');
+      expect(select.options[6].textContent?.trim()).toBe('6.0');
 
       fixture.whenStable().then(() => {
-        expect(select.selectedIndex).toBe(3);
+        expect(select.selectedIndex).toBe(4);
       });
     });
 

--- a/src/app/events/components/grade/grade.component.ts
+++ b/src/app/events/components/grade/grade.component.ts
@@ -46,10 +46,9 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
 
   gradingScaleDisabled$ = this.gradingScaleDisabledSubject$.asObservable();
 
-  points$: Observable<number> = this.pointsSubject$.pipe(
+  points$: Observable<string | null> = this.pointsSubject$.pipe(
     debounceTime(DEBOUNCE_TIME),
-    filter(this.isValid.bind(this)),
-    map(Number)
+    filter(this.isValid.bind(this))
   );
 
   grade$: Observable<number> = this.gradeSubject$.pipe(
@@ -97,16 +96,19 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private isValid(points: string): boolean {
-    if (points === '' || points === null) return false;
+    if (points === '' || points === null) return true;
     if (isNaN(Number(points))) return false;
     return !(Number(points) < 0 || Number(points) > this.maxPoints);
   }
 
-  private buildRequestBodyPointsChange(points: number): TestPointsResult {
+  private buildRequestBodyPointsChange(
+    points: string | null
+  ): TestPointsResult {
+    const newPoints = points === null || points === '' ? null : Number(points);
     return {
       StudentIds: [this.student.Id],
       TestId: this.grade.test.Id,
-      Points: points,
+      Points: newPoints,
     };
   }
 

--- a/src/app/events/components/grade/grade.component.ts
+++ b/src/app/events/components/grade/grade.component.ts
@@ -73,7 +73,7 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
     this.grade$
       .pipe(
         takeUntil(this.destroy$),
-        map(this.buildRuequestBodyForGradeChange.bind(this))
+        map(this.buildRequestBodyForGradeChange.bind(this))
       )
       .subscribe((body) => this.gradeChanged.emit(body));
   }
@@ -112,7 +112,7 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
     };
   }
 
-  private buildRuequestBodyForGradeChange(gradeId: number): TestGradesResult {
+  private buildRequestBodyForGradeChange(gradeId: number): TestGradesResult {
     return {
       StudentIds: [this.student.Id],
       TestId: this.grade.test.Id,

--- a/src/app/events/services/test-state.service.ts
+++ b/src/app/events/services/test-state.service.ts
@@ -13,6 +13,7 @@ import { LoadingService } from 'src/app/shared/services/loading-service';
 import { filter, map, switchMap, take } from 'rxjs/operators';
 import {
   Course,
+  Grading,
   TestGradesResult,
   TestPointsResult,
   UpdatedTestResultResponse,
@@ -262,12 +263,19 @@ export class TestStateService {
       );
   }
 
-  private updateStudentGrades(newGrades: UpdatedTestResultResponse) {
+  private updateStudentGrades(newGrades: {
+    courseId: number;
+    body: UpdatedTestResultResponse;
+  }) {
+    const grading: Grading | undefined = newGrades.body.Gradings.find(
+      (grading: Grading) => grading.EventId === newGrades.courseId
+    );
+    if (grading === undefined) return;
     this.action$.next({
       type: 'updateResult',
       payload: {
-        testResult: newGrades.TestResults[0],
-        grading: newGrades.Gradings[0],
+        testResult: newGrades.body.TestResults[0],
+        grading,
       },
     });
   }

--- a/src/app/shared/components/student-dossier/dossier-grades-edit/dossier-grades-edit.component.ts
+++ b/src/app/shared/components/student-dossier/dossier-grades-edit/dossier-grades-edit.component.ts
@@ -115,8 +115,8 @@ export class DossierGradesEditComponent implements OnInit {
     this.courseService
       .updateTestResult(this.test.CourseId, result)
       .subscribe((response) => {
-        this.gradeId = response.TestResults[0]?.GradeId;
-        this.updatedTest = response;
+        this.gradeId = response.body.TestResults[0]?.GradeId;
+        this.updatedTest = response.body;
         this.closeButtonDisabled$.next(false);
       });
   }

--- a/src/app/shared/models/test.model.ts
+++ b/src/app/shared/models/test.model.ts
@@ -4,9 +4,9 @@ import { LocalDateTimeFromString, Option } from './common-types';
 const Result = t.type({
   TestId: t.number,
   CourseRegistrationId: t.number,
-  GradeId: t.number,
+  GradeId: Option(t.number),
   GradeValue: Option(t.number),
-  GradeDesignation: t.string,
+  GradeDesignation: Option(t.string),
   Points: Option(t.number),
   StudentId: t.number,
   Id: t.string,

--- a/src/app/shared/services/courses-rest.service.spec.ts
+++ b/src/app/shared/services/courses-rest.service.spec.ts
@@ -299,7 +299,7 @@ describe('CoursesRestService', () => {
   ) {
     service
       .updateTestResult(buildCourse(1).Id, requestBody)
-      .subscribe((result) => expect(result).toEqual(responseBody));
+      .subscribe((result) => expect(result.body).toEqual(responseBody));
   }
 
   function assertRequestAndFlush(

--- a/src/app/shared/services/courses-rest.service.ts
+++ b/src/app/shared/services/courses-rest.service.ts
@@ -127,10 +127,13 @@ export class CoursesRestService extends RestService<typeof Course> {
   updateTestResult(
     courseId: number,
     body: TestPointsResult | TestGradesResult
-  ): Observable<UpdatedTestResultResponse> {
+  ): Observable<{ courseId: number; body: UpdatedTestResultResponse }> {
     return this.http
       .put(`${this.baseUrl}/${courseId}/SetTestResult`, body)
-      .pipe(switchMap(decode(UpdatedTestResultResponse)));
+      .pipe(
+        switchMap(decode(UpdatedTestResultResponse)),
+        switchMap((value) => of({ courseId, body: value }))
+      );
   }
 
   setAverageAsFinalGrade(body: {


### PR DESCRIPTION
Löschen einer bestehenden Note für einen Test - Punkte und mit GradingScale

- merkwürdigerweise enthält die Response in diesem Fall alle Gradings eines SuS und nicht nur das Grading des aktuellen Kurses, was dazu geführt hat, dass der Durchschnitt des SuS nicht mehr aktualisiert wurde - ich habe das entsprechend auch noch anpassen müssen. Dazu musste ich die CourseId (EventId) in die Response vom Request rein bringen.

- Ich habe auch noch einen Typo gefixt