### PR TITLE
Remove right/left padding/margin from all modules #576

### DIFF
--- a/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.html
+++ b/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'edit-absences.title' | translate }}</h1>
+<h1>{{ 'edit-absences.title' | translate }}</h1>
 <div
   class="erz-container erz-container-limited erz-container-padding-y"
   *erzLet="{

--- a/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.scss
+++ b/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.scss
@@ -4,6 +4,6 @@
 :host {
   display: flex;
   flex-direction: column;
-  padding: $spacer;
+  padding: $spacer 0;
   border-bottom: 1px solid $border-color;
 }

--- a/src/app/edit-absences/components/edit-absences-list/edit-absences-list.component.html
+++ b/src/app/edit-absences/components/edit-absences-list/edit-absences-list.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'edit-absences.title' | translate }}</h1>
+<h1>{{ 'edit-absences.title' | translate }}</h1>
 <ng-container
   *erzLet="{
     selection: selectionService.selection$ | async,
@@ -19,7 +19,7 @@
           (data.entries && data.entries.length > 0) || data.loadingPage;
           else noEntries
         "
-        class="p-3"
+        class="py-3"
         infiniteScroll
         (scrolled)="onScroll()"
       >
@@ -185,7 +185,7 @@
       </div>
 
       <ng-template #noEntries>
-        <p class="mt-3 px-3">{{ 'edit-absences.no-entries' | translate }}</p>
+        <p class="mt-3">{{ 'edit-absences.no-entries' | translate }}</p>
       </ng-template>
     </ng-container>
 
@@ -195,6 +195,6 @@
   </ng-container>
 
   <ng-template #noFilter>
-    <p class="mt-3 px-3">{{ 'edit-absences.no-filter' | translate }}</p>
+    <p class="mt-3">{{ 'edit-absences.no-filter' | translate }}</p>
   </ng-template>
 </ng-container>

--- a/src/app/evaluate-absences/components/evaluate-absences-header/evaluate-absences-header.component.scss
+++ b/src/app/evaluate-absences/components/evaluate-absences-header/evaluate-absences-header.component.scss
@@ -4,6 +4,6 @@
 :host {
   display: flex;
   flex-direction: column;
-  padding: $spacer;
+  padding: $spacer 0;
   border-bottom: 1px solid $border-color;
 }

--- a/src/app/evaluate-absences/components/evaluate-absences-list/evaluate-absences-list.component.html
+++ b/src/app/evaluate-absences/components/evaluate-absences-list/evaluate-absences-list.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'evaluate-absences.title' | translate }}</h1>
+<h1>{{ 'evaluate-absences.title' | translate }}</h1>
 <ng-container
   *erzLet="{
     entries: state.entries$ | async,
@@ -18,7 +18,7 @@
           (data.entries && data.entries.length > 0) || data.loadingPage;
           else noEntries
         "
-        class="p-3"
+        class="py-3"
       >
         <div class="buttons">
           <a
@@ -99,7 +99,7 @@
       </div>
 
       <ng-template #noEntries>
-        <p class="mt-3 px-3">
+        <p class="mt-3">
           {{ 'evaluate-absences.no-entries' | translate }}
         </p>
       </ng-template>
@@ -111,6 +111,6 @@
   </ng-container>
 
   <ng-template #noFilter>
-    <p class="mt-3 px-3">{{ 'evaluate-absences.no-filter' | translate }}</p>
+    <p class="mt-3">{{ 'evaluate-absences.no-filter' | translate }}</p>
   </ng-template>
 </ng-container>

--- a/src/app/events/components/events-current/events-current.component.html
+++ b/src/app/events/components/events-current/events-current.component.html
@@ -1,2 +1,2 @@
-<h1 class="mx-3">{{ 'events.current.title' | translate }}</h1>
+<h1>{{ 'events.current.title' | translate }}</h1>
 <erz-events-list [withRatings]="false"></erz-events-list>

--- a/src/app/events/components/events-list/events-list.component.scss
+++ b/src/app/events/components/events-list/events-list.component.scss
@@ -57,10 +57,6 @@
 }
 
 @include media-breakpoint-down(sm) {
-  .search {
-    padding: 0 $spacer;
-  }
-
   .event-header {
     display: none;
   }

--- a/src/app/events/components/events-tests/events-tests.component.html
+++ b/src/app/events/components/events-tests/events-tests.component.html
@@ -1,2 +1,2 @@
-<h1 class="mx-3">{{ 'events.title' | translate }}</h1>
+<h1>{{ 'events.title' | translate }}</h1>
 <erz-events-list [withRatings]="true"></erz-events-list>

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
@@ -29,7 +29,7 @@ thead tr th {
 
 .header-collapsible th {
   border-bottom: 1px solid $border-color;
-  padding: 0 $spacer;
+  padding: 0;
 }
 
 .mobile {

--- a/src/app/events/components/tests-add/tests-add.component.html
+++ b/src/app/events/components/tests-add/tests-add.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'tests.add-title' | translate }}</h1>
+<h1>{{ 'tests.add-title' | translate }}</h1>
 <div
   class="erz-container erz-container-limited erz-container-padding-y"
   *erzLet="{ courseId: courseId$ | async, saving: saving$ | async } as data"

--- a/src/app/events/components/tests-header/tests-header.component.scss
+++ b/src/app/events/components/tests-header/tests-header.component.scss
@@ -12,10 +12,3 @@ h1 {
   padding-bottom: $spacer;
   border-bottom: 1px solid $border-color;
 }
-
-@media (max-width: 750px) {
-  .header {
-    padding-right: $spacer;
-    padding-left: calc($spacer / 2);
-  }
-}

--- a/src/app/events/components/tests-list/tests-list.component.scss
+++ b/src/app/events/components/tests-list/tests-list.component.scss
@@ -3,7 +3,7 @@
 
 .tests-dropdown {
   display: block;
-  padding: $spacer;
+  padding: $spacer 0;
 }
 
 @include media-breakpoint-up(sm) {

--- a/src/app/my-absences/components/my-absences-report-header/my-absences-report-header.component.scss
+++ b/src/app/my-absences/components/my-absences-report-header/my-absences-report-header.component.scss
@@ -3,7 +3,7 @@
 
 :host {
   display: block;
-  padding: $spacer;
+  padding: $spacer 0;
   border-bottom: 1px solid $border-color;
 }
 

--- a/src/app/my-absences/components/my-absences-report-list/my-absences-report-list.component.html
+++ b/src/app/my-absences/components/my-absences-report-list/my-absences-report-list.component.html
@@ -17,7 +17,7 @@
           (data.entries && data.entries.length > 0) || data.loadingPage;
           else noEntries
         "
-        class="p-3"
+        class="py-3"
       >
         <div *ngIf="data.entries && data.entries.length > 0">
           <div class="entries-all" #all (click)="onRowClick($event, all)">
@@ -111,7 +111,7 @@
       </div>
 
       <ng-template #noEntries>
-        <p class="mt-3 px-3">
+        <p class="mt-3">
           {{ 'my-absences.report.no-entries' | translate }}
         </p>
       </ng-template>
@@ -123,6 +123,6 @@
   </ng-container>
 
   <ng-template #noFilter>
-    <p class="mt-3 px-3">{{ 'my-absences.report.no-filter' | translate }}</p>
+    <p class="mt-3">{{ 'my-absences.report.no-filter' | translate }}</p>
   </ng-template>
 </ng-container>

--- a/src/app/my-absences/components/my-absences-show/my-absences-show.component.html
+++ b/src/app/my-absences/components/my-absences-show/my-absences-show.component.html
@@ -4,7 +4,7 @@
     absenceCounts: myAbsencesService.counts$ | async
   } as data"
 >
-  <h1 class="mx-3">{{ 'my-absences.title' | translate }}</h1>
+  <h1>{{ 'my-absences.title' | translate }}</h1>
   <div class="d-flex justify-content-between border-bottom header">
     <div>{{ 'my-absences.description' | translate }}</div>
     <div>

--- a/src/app/my-absences/components/my-absences-show/my-absences-show.component.scss
+++ b/src/app/my-absences/components/my-absences-show/my-absences-show.component.scss
@@ -1,12 +1,5 @@
 @import "../../../../bootstrap-variables";
 
 .header {
-  padding-left: $spacer;
   padding-bottom: $spacer;
-}
-
-@media (max-width: 750px) {
-  .header {
-    padding-right: $spacer;
-  }
 }

--- a/src/app/my-grades/components/my-grades-header/my-grades-header.component.scss
+++ b/src/app/my-grades/components/my-grades-header/my-grades-header.component.scss
@@ -1,14 +1,7 @@
 @import "../../../../bootstrap-variables";
 
 .header {
-  padding-left: $spacer;
   padding-bottom: $spacer;
-}
-
-@media (max-width: 750px) {
-  .header {
-    padding-right: $spacer;
-  }
 }
 
 .report {

--- a/src/app/my-grades/components/my-grades-show/my-grades-show.component.html
+++ b/src/app/my-grades/components/my-grades-show/my-grades-show.component.html
@@ -7,7 +7,7 @@
     gradingScales: myGradesService.gradingScales$ | async
   } as data"
 >
-  <h1 class="mx-3">{{ 'my-grades.title' | translate }}</h1>
+  <h1>{{ 'my-grades.title' | translate }}</h1>
   <erz-my-grades-header></erz-my-grades-header>
   <erz-dossier-grades-view
     *ngIf="!data.loading"

--- a/src/app/my-profile/components/my-profile-header/my-profile-header.component.scss
+++ b/src/app/my-profile/components/my-profile-header/my-profile-header.component.scss
@@ -3,7 +3,7 @@
 .avatar-person {
   display: flex;
   justify-content: space-between;
-  padding-left: $spacer;
+  padding-left: $spacer 0;
 }
 
 .person {
@@ -11,7 +11,7 @@
 }
 
 .email {
-  padding: $spacer 0 0 $spacer;
+  padding-top: $spacer;
 }
 
 .report {

--- a/src/app/my-profile/components/my-profile-show/my-profile-show.component.html
+++ b/src/app/my-profile/components/my-profile-show/my-profile-show.component.html
@@ -4,7 +4,7 @@
     profile: profileService.profile$ | async
   } as data"
 >
-  <h1 class="mx-3">{{ 'my-profile.title' | translate }}</h1>
+  <h1>{{ 'my-profile.title' | translate }}</h1>
   <ng-container
     *ngIf="(profileService.loading$ | async) === false; else loading"
   >

--- a/src/app/open-absences/components/open-absences-detail/open-absences-detail.component.html
+++ b/src/app/open-absences/components/open-absences-detail/open-absences-detail.component.html
@@ -1,4 +1,4 @@
-<div class="px-3">
+<div>
   <erz-backlink [routerLink]="['/open-absences']" class="mb-3"></erz-backlink>
   <h1>{{ studentFullName$ | async }}</h1>
 </div>

--- a/src/app/open-absences/components/open-absences-list/open-absences-list.component.html
+++ b/src/app/open-absences/components/open-absences-list/open-absences-list.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'open-absences.title' | translate }}</h1>
+<h1>{{ 'open-absences.title' | translate }}</h1>
 <div
   *erzLet="{
     selection: selectionService.selection$ | async,
@@ -16,7 +16,7 @@
         else noEntries
       "
     >
-      <div class="pt-3 ps-3 pe-3">
+      <div class="pt-3">
         <erz-resettable-input
           class="d-flex header-search"
           [value]="openAbsencesService.search$ | async"

--- a/src/app/open-absences/components/open-absences-list/open-absences-list.component.scss
+++ b/src/app/open-absences/components/open-absences-list/open-absences-list.component.scss
@@ -1,10 +1,5 @@
 @import "../../../../bootstrap-variables";
 
-.content {
-  padding-left: $spacer;
-  padding-right: $spacer;
-}
-
 .header-search {
   max-width: 500px;
 }

--- a/src/app/presence-control/components/presence-control-header/presence-control-header.component.scss
+++ b/src/app/presence-control/components/presence-control-header/presence-control-header.component.scss
@@ -3,7 +3,7 @@
 :host {
   display: flex;
   flex-direction: column;
-  padding: 0.75 * $spacer $spacer;
+  padding: 0.75 * $spacer 0;
 }
 
 /**

--- a/src/app/presence-control/components/presence-control-list/presence-control-list.component.html
+++ b/src/app/presence-control/components/presence-control-list/presence-control-list.component.html
@@ -1,4 +1,4 @@
-<h1 class="mx-3">{{ 'presence-control.title' | translate }}</h1>
+<h1>{{ 'presence-control.title' | translate }}</h1>
 <ng-container
   *erzLet="{
     lesson: state.selectedLesson$ | async,
@@ -47,14 +47,14 @@
       </ng-container>
 
       <ng-template #noLessonPresences>
-        <p class="mt-3 ps-3">
+        <p class="mt-3">
           {{ 'presence-control.no-lesson-presences' | translate }}
         </p>
       </ng-template>
     </ng-container>
 
     <ng-template #noLessons>
-      <p class="mt-3 px-3">{{ 'presence-control.no-lessons' | translate }}</p>
+      <p class="mt-3">{{ 'presence-control.no-lessons' | translate }}</p>
     </ng-template>
   </ng-container>
 

--- a/src/app/shared/components/student-dossier/dossier-grades-view/dossier-grades-view.component.html
+++ b/src/app/shared/components/student-dossier/dossier-grades-view/dossier-grades-view.component.html
@@ -36,7 +36,7 @@
 </ng-container>
 
 <ng-template #noCourses
-  ><p class="p-3" data-testid="message-no-courses">
+  ><p class="py-3" data-testid="message-no-courses">
     {{ 'dossier.no-courses' | translate }}
   </p></ng-template
 >

--- a/src/app/shared/components/student-dossier/student-backlink/student-backlink.component.html
+++ b/src/app/shared/components/student-dossier/student-backlink/student-backlink.component.html
@@ -1,4 +1,4 @@
-<div class="d-flex flex-column mx-3">
+<div class="d-flex flex-column">
   <erz-backlink
     [routerLink]="link"
     [queryParams]="queryParams"

--- a/src/app/shared/components/student-dossier/student-dossier/student-dossier.component.html
+++ b/src/app/shared/components/student-dossier/student-dossier/student-dossier.component.html
@@ -17,7 +17,7 @@
           [studentId]="state.studentId$ | async"
           [student]="data.profile && data.profile.student"
         ></erz-student-backlink>
-        <div class="me-3">
+        <div>
           <a
             *ngIf="data.currentDossierSection === 'grades'"
             class="edit btn btn-primary btn-icon ms-2"
@@ -28,7 +28,7 @@
           </a>
         </div>
       </div>
-      <div class="d-flex flex-row p-3 flex-wrap">
+      <div class="d-flex flex-row py-3 flex-wrap">
         <a
           [queryParams]="{ returnparams: state.returnParams$ | async }"
           [routerLink]="[section]"

--- a/src/bootstrap-variables.scss
+++ b/src/bootstrap-variables.scss
@@ -90,7 +90,7 @@ $btn-border-radius: (($btn-line-height * $btn-font-size) + (2 * $btn-padding-y))
 
 // Custom variables
 $erz-container-max-width: 960px;
-$erz-container-padding-x: $spacer;
+$erz-container-padding-x: 0;
 $erz-container-padding-y: $spacer;
 
 $erz-presence-control-entry-min-width: 400px;


### PR DESCRIPTION
Umsetzung von https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/576

Da das neue Evento-Portal selbst schon horizontales Padding/Margin hat, sollen die Ränder in unserer App entfernt werden.
Leider haben wir es überall ein bisschen anders gemacht... Ich bin nicht sicher ob ich alle betroffenen Stellen gefunden habe.

Das Modul "dashboard" ist neu und deshalb schon entsprechend umgesetzt.

Ich mache noch einen zweiten Pull-Request zum Integrieren des neuen Builds der webapp-schulverwaltung ins Evento-Portal. Die Änderungen direkt dort manuell anzuschauen macht wohl mehr Sinn.