### PR TITLE
530 actions

### DIFF
--- a/src/app/dashboard/components/dashboard-action/dashboard-action.component.html
+++ b/src/app/dashboard/components/dashboard-action/dashboard-action.component.html
@@ -10,7 +10,7 @@
   <span class="label">{{ label | translate }}</span>
   <div>
     <ng-content></ng-content>
-    <span class="count" *ngIf="count; else icon">{{ count }}</span>
+    <span class="count" *ngIf="count >= 0; else icon">{{ count }}</span>
     <ng-template #icon>
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
@@ -60,6 +60,12 @@ describe('DashboardActionsComponent', () => {
               getLessonAbsences() {
                 return of([]);
               },
+              getLessonIncidents() {
+                return of([]);
+              },
+              getTimetableEntries() {
+                return of([]);
+              },
             },
           },
           {

--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
@@ -45,7 +45,7 @@ describe('DashboardActionsComponent', () => {
                 return of(true);
               },
               checkableAbsencesCount() {
-                return of(6);
+                return of(0);
               },
               getListOfUnconfirmed() {
                 return of([
@@ -58,7 +58,7 @@ describe('DashboardActionsComponent', () => {
             provide: StudentsRestService,
             useValue: {
               getLessonAbsences() {
-                return [];
+                return of([]);
               },
             },
           },
@@ -80,22 +80,6 @@ describe('DashboardActionsComponent', () => {
                 return of([
                   buildLessonPresence(1, new Date(), new Date(), 'Math'),
                 ]);
-              },
-            },
-          },
-          {
-            provide: StudentsRestService,
-            useValue: {
-              getLessonAbsences() {
-                return [];
-              },
-            },
-          },
-          {
-            provide: StorageService,
-            useValue: {
-              getPayload(): any {
-                return { id_person: '123' };
               },
             },
           },
@@ -150,8 +134,8 @@ describe('DashboardActionsComponent', () => {
       expect(element.textContent).toContain(
         'dashboard.actions.presence-control'
       );
-      expect(element.textContent).toContain('dashboard.actions.edit-absences');
-      expect(element.textContent).toContain('dashboard.actions.open-absences');
+      expect(element.textContent).toContain('dashboard.actions.edit-absences0');
+      expect(element.textContent).toContain('dashboard.actions.open-absences1');
       expect(element.textContent).not.toContain('dashboard.actions.tests');
       expect(element.textContent).not.toContain(
         'dashboard.actions.my-absences-report'
@@ -178,7 +162,7 @@ describe('DashboardActionsComponent', () => {
       expect(element.textContent).not.toContain(
         'dashboard.actions.edit-absences'
       );
-      expect(element.textContent).toContain('dashboard.actions.open-absences');
+      expect(element.textContent).toContain('dashboard.actions.open-absences1');
       expect(element.textContent).not.toContain('dashboard.actions.tests');
       expect(element.textContent).not.toContain(
         'dashboard.actions.my-absences-report'
@@ -242,7 +226,7 @@ describe('DashboardActionsComponent', () => {
       expect(element.textContent).toContain(
         'dashboard.actions.my-absences-report'
       );
-      expect(element.textContent).toContain('dashboard.actions.my-absences');
+      expect(element.textContent).toContain('dashboard.actions.my-absences0');
       expect(element.textContent).not.toContain(
         'dashboard.actions.substitutions'
       );

--- a/src/app/dashboard/services/dashboard.service.ts
+++ b/src/app/dashboard/services/dashboard.service.ts
@@ -1,5 +1,12 @@
 import { Inject, Injectable } from '@angular/core';
-import { map, of, ReplaySubject, shareReplay, switchMap, startWith } from 'rxjs';
+import {
+  map,
+  of,
+  ReplaySubject,
+  shareReplay,
+  switchMap,
+  startWith,
+} from 'rxjs';
 import { Settings, SETTINGS } from '../../settings';
 import { UserSettingsService } from '../../shared/services/user-settings.service';
 import { LessonPresencesRestService } from '../../shared/services/lesson-presences-rest.service';

--- a/src/app/dashboard/services/dashboard.service.ts
+++ b/src/app/dashboard/services/dashboard.service.ts
@@ -1,11 +1,13 @@
 import { Inject, Injectable } from '@angular/core';
 import {
+  combineLatest,
   map,
+  Observable,
   of,
   ReplaySubject,
   shareReplay,
-  switchMap,
   startWith,
+  switchMap,
 } from 'rxjs';
 import { Settings, SETTINGS } from '../../settings';
 import { UserSettingsService } from '../../shared/services/user-settings.service';
@@ -14,6 +16,9 @@ import { StudentsRestService } from '../../shared/services/students-rest.service
 import { LessonAbsence } from '../../shared/models/lesson-absence.model';
 import { StorageService } from '../../shared/services/storage.service';
 import { CoursesRestService } from '../../shared/services/courses-rest.service';
+import { LessonIncident } from '../../shared/models/lesson-incident.model';
+import { TimetableEntry } from '../../shared/models/timetable-entry.model';
+import { notNull } from '../../shared/utils/filter';
 
 const SEARCH_ROLES = [
   'LessonTeacherRole',
@@ -35,6 +40,14 @@ const TIMETABLE_ROLES = ['LessonTeacherRole', 'StudentRole'];
 export class DashboardService {
   private rolesAndPermissions$ = this.settingsService.getRolesAndPermissions();
   studentId$ = new ReplaySubject<number>(1);
+  private lessonAbsences$ = this.studentId$.pipe(
+    switchMap((id) => this.studentsService.getLessonAbsences(id)),
+    shareReplay(1)
+  );
+  private lessonIncidents$ = this.studentId$.pipe(
+    switchMap((id) => this.studentsService.getLessonIncidents(id)),
+    shareReplay(1)
+  );
 
   ///// Dashboard Conditions /////
 
@@ -85,13 +98,7 @@ export class DashboardService {
   );
 
   myAbsencesCount$ = this.hasStudentRole$.pipe(
-    switchMap((hasRole) =>
-      hasRole
-        ? this.studentId$.pipe(
-            switchMap((id) => this.studentsService.getLessonAbsences(id))
-          )
-        : of([])
-    ),
+    switchMap((hasRole) => (hasRole ? this.getMyAbsences() : of([]))),
     map(this.getMyAbsencesCount.bind(this)),
     shareReplay(1)
   );
@@ -135,10 +142,59 @@ export class DashboardService {
       (actualRoles ?? []).some((role) => requiredRoles.includes(role));
   }
 
-  private getMyAbsencesCount(absences: ReadonlyArray<LessonAbsence>): number {
-    return absences.filter(
-      (absence) =>
-        absence.ConfirmationStateId === this.settings.unconfirmedAbsenceStateId
-    ).length;
+  private getMyAbsences(): Observable<
+    Option<ReadonlyArray<LessonAbsence | LessonIncident>>
+  > {
+    return combineLatest([
+      this.studentId$,
+      this.lessonAbsences$,
+      this.lessonIncidents$,
+    ]).pipe(
+      switchMap(([studentId, absences, incidents]) =>
+        this.loadTimetableEntries(studentId, absences, incidents).pipe(
+          map((timetableEntries) =>
+            [...absences, ...incidents]
+              .map((absence) =>
+                this.withTimetableEntry(absence, timetableEntries)
+              )
+              .filter(notNull)
+          )
+        )
+      )
+    );
+  }
+
+  private getMyAbsencesCount(
+    absences: Option<ReadonlyArray<LessonAbsence | LessonIncident>>
+  ): number {
+    return (
+      absences?.filter(
+        (absence) =>
+          ('ConfirmationStateId' in absence
+            ? absence.ConfirmationStateId
+            : null) === this.settings.unconfirmedAbsenceStateId
+      ).length || 0
+    );
+  }
+
+  private withTimetableEntry(
+    absence: LessonAbsence | LessonIncident,
+    timetableEntries: ReadonlyArray<TimetableEntry>
+  ): Option<LessonAbsence | LessonIncident> {
+    return timetableEntries.find((e) => e.Id === absence.LessonRef.Id)
+      ? absence
+      : null;
+  }
+
+  private loadTimetableEntries(
+    studentId: number,
+    absences: ReadonlyArray<LessonAbsence>,
+    incidents: ReadonlyArray<LessonIncident>
+  ): Observable<ReadonlyArray<TimetableEntry>> {
+    return this.studentsService.getTimetableEntries(studentId, {
+      'filter.Id': `;${[...absences, ...incidents]
+        .map((e) => e.LessonRef.Id)
+        .join(';')}`,
+    });
   }
 }


### PR DESCRIPTION
Siehe auch Kommentare in https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/530

- Auf dem Dashboard soll bei allen Kacheln die Zahl 0 angezeigt werden, wenn die Anzahl der Elemente 0 ist. Bisher wurde bei `null`, `undefined` und 0 stattdessen das Icon (der Pfeil) angezeigt
- Der Request zur Abfrage von Kachel "Offene Absenzen entschuldigen" (sichtbar für Schüler) war nicht ganz richtig. Er wurde nun demjenigen Request angepasst, welcher bei der Rubrik "Offene Absenzen" gemacht wird, wenn man auf die Kachel klickt ("Meine Absenzen")