### PR TITLE
Bug/532 notenfrist

### DIFF
--- a/src/app/shared/services/courses-rest.service.spec.ts
+++ b/src/app/shared/services/courses-rest.service.spec.ts
@@ -2,7 +2,11 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { isEqual } from 'lodash-es';
 import { buildTestModuleMetadata } from 'src/spec-helpers';
-import { buildCourse, buildResult } from '../../../spec-builders';
+import {
+  buildCourse,
+  buildReference,
+  buildResult,
+} from '../../../spec-builders';
 import {
   AverageTestResultResponse,
   Course,
@@ -25,7 +29,22 @@ describe('CoursesRestService', () => {
   afterEach(() => httpTestingController.verify());
 
   describe('getNumberOfCoursesForRating', () => {
-    it('should return all course ids for the given status ids', () => {
+    it('should return the number of courses where the evaluation has started', () => {
+      const ratingStarted = {
+        ...buildCourse(1001, 'Course with HasEvaluationStarted true'),
+        EvaluationStatusRef: {
+          ...buildReference(),
+          HasEvaluationStarted: true,
+        },
+      };
+      const ratingNotStarted = {
+        ...buildCourse(1002, 'Course with HasEvaluationStarted false'),
+        EvaluationStatusRef: {
+          ...buildReference(),
+          HasEvaluationStarted: false,
+        },
+      };
+
       service.getNumberOfCoursesForRating().subscribe((result) => {
         expect(result).toEqual(1);
       });
@@ -36,19 +55,7 @@ describe('CoursesRestService', () => {
               'https://eventotest.api/Courses/?expand=EvaluationStatusRef&fields=Id,StatusId,EvaluationStatusRef&filter.StatusId=;10300;10240' &&
             req.headers.get('X-Role-Restriction') === 'TeacherRole'
         )
-        .flush([
-          {
-            Id: 6402,
-            StatusId: 10300,
-            EvaluationStatusRef: {
-              HasEvaluationStarted: true,
-              EvaluationUntil: null,
-              HasReviewOfEvaluationStarted: false,
-              HasTestGrading: false,
-              Id: 10101,
-            },
-          },
-        ]);
+        .flush([ratingNotStarted, ratingStarted]);
     });
   });
 

--- a/src/app/shared/services/courses-rest.service.spec.ts
+++ b/src/app/shared/services/courses-rest.service.spec.ts
@@ -33,10 +33,22 @@ describe('CoursesRestService', () => {
         .expectOne(
           (req) =>
             req.urlWithParams ===
-              'https://eventotest.api/Courses/?fields=Id,StatusId&filter.StatusId=;10300;10240' &&
+              'https://eventotest.api/Courses/?expand=EvaluationStatusRef&fields=Id,StatusId,EvaluationStatusRef&filter.StatusId=;10300;10240' &&
             req.headers.get('X-Role-Restriction') === 'TeacherRole'
         )
-        .flush([{ Id: 6402 }]);
+        .flush([
+          {
+            Id: 6402,
+            StatusId: 10300,
+            EvaluationStatusRef: {
+              HasEvaluationStarted: true,
+              EvaluationUntil: null,
+              HasReviewOfEvaluationStarted: false,
+              HasTestGrading: false,
+              Id: 10101,
+            },
+          },
+        ]);
     });
   });
 


### PR DESCRIPTION
Betrifft: Dashboard > Kachel "Tests und Bewertung" > Anzahl in Pill "Notenfrist"

Die Anzahl sollte der Anzahl Tests auf der Seite "Tests und Bewertung" entsprechen, welche einen Link "Bewertung bis..." oder "Zwischenbewertung" haben.

Siehe auch https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/532 insbesondere Kommentar https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/532#issuecomment-1642155626.