### PR TITLE
Add teacher full name to edit absences params #530

### DIFF
--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
@@ -80,7 +80,7 @@ describe('DashboardActionsComponent', () => {
             provide: StorageService,
             useValue: {
               getPayload(): any {
-                return { id_person: '123' };
+                return { id_person: '123', fullName: 'Stolz Zuzana' };
               },
               getListOfUnconfirmed() {
                 return of([
@@ -134,9 +134,6 @@ describe('DashboardActionsComponent', () => {
 
     it('displays presence control, edit and open absences', () => {
       fixture.detectChanges();
-      expect(element.textContent).toContain(
-        'dashboard.actions.presence-control'
-      );
       expect(element.textContent).toContain(
         'dashboard.actions.presence-control'
       );

--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject } from '@angular/core';
 import { Settings, SETTINGS } from '../../../settings';
 import { Params } from '@angular/router';
 import { DashboardService } from '../../services/dashboard.service';
+import { StorageService } from '../../../shared/services/storage.service';
 
 @Component({
   selector: 'erz-dashboard-actions',
@@ -11,11 +12,15 @@ import { DashboardService } from '../../services/dashboard.service';
 export class DashboardActionsComponent {
   constructor(
     public dashboardService: DashboardService,
+    private storageService: StorageService,
     @Inject(SETTINGS) public settings: Settings
   ) {}
 
   get editAbsencesParams(): Params {
-    return { confirmationStates: this.settings.checkableAbsenceStateId };
+    return {
+      confirmationStates: this.settings.checkableAbsenceStateId,
+      teacher: this.storageService.getPayload()?.fullname,
+    };
   }
 
   get substitutionsAdminLink(): string {


### PR DESCRIPTION
Der Link auf der Kachel "Gemeldete Absenzen kontrollieren" soll zum Modul "Absenzen bearbeiten" führen und diese Liste zusätzlich zum Status ("zu kontrollieren") nach der eingeloggten Lehrperson filtern.

Siehe https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/530#issuecomment-1645085009