### PR TITLE
Render dash for test averages without grades

### DIFF
--- a/src/app/events/components/grades/average-grades/average-grades.component.spec.ts
+++ b/src/app/events/components/grades/average-grades/average-grades.component.spec.ts
@@ -54,13 +54,13 @@ describe("AverageGradesComponent", () => {
     expectText(fixture.debugElement, "average-grade", "5.875");
   });
 
-  it("should show '-' for tests with no results", () => {
+  it("should show '–' for tests with no results", () => {
     const testWithNoResults = buildTest(1, 1, []);
     testWithNoResults.IsPointGrading = true;
     component.test = testWithNoResults;
     fixture.detectChanges();
 
-    expectText(fixture.debugElement, "average-grade", "-");
-    expectText(fixture.debugElement, "average-points", "-");
+    expectText(fixture.debugElement, "average-grade", "–");
+    expectText(fixture.debugElement, "average-points", "–");
   });
 });

--- a/src/app/events/components/grades/average-grades/average-grades.component.ts
+++ b/src/app/events/components/grades/average-grades/average-grades.component.ts
@@ -1,7 +1,10 @@
-import { Component, Input } from "@angular/core";
+import { Component, Inject, Input, LOCALE_ID } from "@angular/core";
 import { averageGrade, averagePoints } from "src/app/events/utils/tests";
 import { Test } from "src/app/shared/models/test.model";
-import { DecimalPipe } from "@angular/common";
+import {
+  DASH,
+  formatDecimalOrDash,
+} from "src/app/shared/pipes/decimal-or-dash.pipe";
 
 @Component({
   selector: "erz-average-grades",
@@ -15,11 +18,10 @@ import { DecimalPipe } from "@angular/common";
     <span data-testid="average-grade">{{ calculateGradeAverage(test) }}</span>
   </div>`,
   styleUrls: ["./average-grades.component.scss"],
-  providers: [DecimalPipe],
 })
 export class AverageGradesComponent {
   @Input() test: Test;
-  constructor(private decimalPipe: DecimalPipe) {}
+  constructor(@Inject(LOCALE_ID) private locale: string) {}
 
   calculatePointsAverage(test: Test) {
     return this.safeAverage(test, 2, averagePoints);
@@ -31,17 +33,13 @@ export class AverageGradesComponent {
 
   private safeAverage(
     test: Test,
-    fractionDigits: number,
+    fractionDigits: number | string,
     strategy: (test: Test) => number,
   ): string {
     try {
-      return (
-        this.decimalPipe
-          .transform(strategy(test), `1.${fractionDigits}`)
-          ?.toString() ?? "-"
-      );
+      return formatDecimalOrDash(strategy(test), this.locale, fractionDigits);
     } catch {
-      return "-";
+      return DASH;
     }
   }
 }

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -145,7 +145,7 @@
               <span>{{ studentGrade.student.FullName }}</span>
               <span class="mobile mean">
                 {{ "tests.mean" | translate }}:
-                {{ studentGrade.finalGrade?.average | number: "1.0-3" }}
+                {{ studentGrade.finalGrade?.average | decimalOrDash: "1-3" }}
               </span>
             </a>
           </td>
@@ -175,7 +175,7 @@
             </div>
           </td>
           <td class="grade border-end sticky sticky-col-3">
-            {{ studentGrade.finalGrade?.average | number: "1.0-3" }}
+            {{ studentGrade.finalGrade?.average | decimalOrDash: "1-3" }}
           </td>
           <td
             *ngFor="
@@ -207,7 +207,9 @@
               <div class="mobile mean">
                 {{ "tests.mean" | translate }}:
                 {{
-                  state.meanOfStudentGradesForCourse$ | async | number: "1.0-3"
+                  state.meanOfStudentGradesForCourse$
+                    | async
+                    | decimalOrDash: "1-3"
                 }}
               </div>
             </div>
@@ -216,10 +218,14 @@
             class="desktop sticky sticky sticky-col-2"
             [ngClass]="{ selected: selectedTest === undefined }"
           >
-            {{ state.meanOfFinalGradesForCourse$ | async | number: "1.0-3" }}
+            {{
+              state.meanOfFinalGradesForCourse$ | async | decimalOrDash: "1-3"
+            }}
           </td>
           <td class="desktop border-end sticky sticky-col-3">
-            {{ state.meanOfStudentGradesForCourse$ | async | number: "1.0-3" }}
+            {{
+              state.meanOfStudentGradesForCourse$ | async | decimalOrDash: "1-3"
+            }}
           </td>
           <td
             *ngFor="let test of data.tests"

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.ts
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.ts
@@ -95,7 +95,7 @@ export class TestEditGradesComponent implements OnInit {
     try {
       return calculator(test).toString();
     } catch {
-      return "-";
+      return "–";
     }
   }
 

--- a/src/app/shared/components/student-dossier/dossier-grades-final-grade/dossier-grades-final-grade.component.spec.ts
+++ b/src/app/shared/components/student-dossier/dossier-grades-final-grade/dossier-grades-final-grade.component.spec.ts
@@ -51,6 +51,6 @@ describe("DossierGradesFinalGradeComponent", () => {
   it("should show dash if average is zero", () => {
     component.average = 0;
     fixture.detectChanges();
-    expectText(debugElement, "average-test-results", "-");
+    expectText(debugElement, "average-test-results", "–");
   });
 });

--- a/src/app/shared/components/student-dossier/dossier-grades-final-grade/dossier-grades-final-grade.component.ts
+++ b/src/app/shared/components/student-dossier/dossier-grades-final-grade/dossier-grades-final-grade.component.ts
@@ -9,11 +9,11 @@ import { DecimalPipe } from "@angular/common";
   template: `<div class="final-entry">
     <div>{{ "dossier.grade" | translate }}</div>
     <div data-testid="final-grade">
-      <span>{{ getGradeForStudent() || "-" }}</span>
+      <span>{{ getGradeForStudent() || "–" }}</span>
     </div>
     <div>{{ "dossier.average" | translate }}</div>
     <div data-testid="average-test-results">
-      <span>{{ average === 0 ? "-" : (average | number: "1.1-3") }}</span>
+      <span>{{ average | decimalOrDash: "1-3" }}</span>
     </div>
   </div>`,
   styleUrls: ["./dossier-grades-final-grade.component.scss"],

--- a/src/app/shared/components/student-dossier/dossier-single-test/dossier-single-test.component.spec.ts
+++ b/src/app/shared/components/student-dossier/dossier-single-test/dossier-single-test.component.spec.ts
@@ -68,8 +68,8 @@ describe("DossierSingleTestComponent", () => {
     expectText(debugElement, "test-date", "22.02.2022");
   });
 
-  it("should show '-' if no results are available in test", () => {
-    expectText(debugElement, "test-grade", "-");
+  it("should show '–' if no results are available in test", () => {
+    expectText(debugElement, "test-grade", "–");
   });
 
   it("should show test summary (factor, weight)", () => {

--- a/src/app/shared/components/student-dossier/dossier-single-test/dossier-single-test.component.ts
+++ b/src/app/shared/components/student-dossier/dossier-single-test/dossier-single-test.component.ts
@@ -100,7 +100,7 @@ export class DossierSingleTestComponent implements OnChanges {
     return (
       this.gradingScale?.Grades.find(
         (grade) => grade.Id === this.getGradeId(test),
-      )?.Designation || "-"
+      )?.Designation || "–"
     );
   }
 

--- a/src/app/shared/pipes/decimal-or-dash.pipe.spec.ts
+++ b/src/app/shared/pipes/decimal-or-dash.pipe.spec.ts
@@ -1,0 +1,52 @@
+import { DecimalOrDashPipe } from "./decimal-or-dash.pipe";
+
+describe("DecimalOrDashPipe", () => {
+  let pipe: DecimalOrDashPipe;
+
+  beforeEach(() => {
+    pipe = new DecimalOrDashPipe("en");
+  });
+
+  it("returns dash for empty string", () => {
+    expect(pipe.transform("")).toBe("–");
+  });
+
+  it("returns dash for zero string", () => {
+    expect(pipe.transform("0")).toBe("–");
+  });
+
+  it("returns dash for zero number", () => {
+    expect(pipe.transform(0)).toBe("–");
+  });
+
+  it("returns dash for undefined", () => {
+    expect(pipe.transform(undefined)).toBe("–");
+  });
+
+  it("returns dash for null", () => {
+    expect(pipe.transform(null)).toBe("–");
+  });
+
+  it("returns dash for any non-number string", () => {
+    expect(pipe.transform("foobar")).toBe("–");
+  });
+
+  it("returns value for number", () => {
+    expect(pipe.transform(123)).toBe("123.0");
+  });
+
+  it("returns value for decimal number", () => {
+    expect(pipe.transform(123.456789)).toBe("123.457");
+  });
+
+  it("returns value for decimal number with custom fraction digits", () => {
+    expect(pipe.transform(123.456789, 2)).toBe("123.46");
+    expect(pipe.transform(123, 2)).toBe("123.00");
+
+    expect(pipe.transform(123.456789, "0-2")).toBe("123.46");
+    expect(pipe.transform(123, "0-2")).toBe("123");
+
+    expect(pipe.transform(123.456789, "1-3")).toBe("123.457");
+    expect(pipe.transform(123, "1-3")).toBe("123.0");
+  });
+});

--- a/src/app/shared/pipes/decimal-or-dash.pipe.ts
+++ b/src/app/shared/pipes/decimal-or-dash.pipe.ts
@@ -1,0 +1,71 @@
+import { formatNumber } from "@angular/common";
+import { Inject, LOCALE_ID, Pipe, PipeTransform } from "@angular/core";
+
+const FRACTION_DIGITS_DEFAULT = "1-3";
+export const DASH = "–";
+
+@Pipe({
+  name: "decimalOrDash",
+})
+export class DecimalOrDashPipe implements PipeTransform {
+  constructor(@Inject(LOCALE_ID) private locale: string) {}
+
+  transform(
+    value: number | string | null | undefined,
+
+    /**
+     * Either a fixed fragtion digit amount as number or string
+     * (e.g. 3) or a range (min/max, e.g. "0-3" or "1-2"). The integer
+     * digits are hardcoded to a minimum of 1. If omitted the setting
+     * is "1-3".
+     *
+     * See also https://angular.io/api/common/DecimalPipe#digitsinfo
+     */
+    fractionDigits?: number | string,
+
+    locale?: string,
+  ): string {
+    const number = Number(value ?? null);
+    if (isNaN(number)) return DASH;
+
+    return formatDecimalOrDash(
+      Number(value ?? null),
+      locale ?? this.locale,
+      fractionDigits,
+    );
+  }
+}
+
+export function formatDecimalOrDash(
+  value: number,
+  locale: string,
+
+  /**
+   * Either a fixed fragtion digit amount as number or string (e.g. 3)
+   * or a range (min/max, e.g. "0-3" or "1-2"). The integer digits are
+   * hardcoded to a minimum of 1. If omitted the setting is "1-3".
+   *
+   * See also https://angular.io/api/common/DecimalPipe#digitsinfo
+   */
+  fractionDigits?: number | string,
+): string {
+  return value === 0
+    ? DASH
+    : formatNumber(
+        value,
+        locale,
+        `1.${normalizeFractionDigits(fractionDigits)}`,
+      );
+}
+
+function normalizeFractionDigits(fractionDigits?: number | string): string {
+  if (!fractionDigits) {
+    return FRACTION_DIGITS_DEFAULT;
+  }
+
+  if (!String(fractionDigits).includes("-")) {
+    return `${fractionDigits}-${fractionDigits}`;
+  }
+
+  return String(fractionDigits);
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { StudentDossierAbsencesComponent } from "./components/student-dossier/st
 import { ConfirmAbsencesComponent } from "./components/confirm-absences/confirm-absences.component";
 import { PersonEmailPipe } from "./pipes/person-email.pipe";
 import { DaysDifferencePipe } from "./pipes/days-difference.pipe";
+import { DecimalOrDashPipe } from "./pipes/decimal-or-dash.pipe";
 import { ResettableInputComponent } from "./components/resettable-input/resettable-input.component";
 import { SafePipe } from "./pipes/safe.pipe";
 import { XssPipe } from "./pipes/xss.pipe";
@@ -69,6 +70,7 @@ const components = [
   ConfirmAbsencesComponent,
   PersonEmailPipe,
   DaysDifferencePipe,
+  DecimalOrDashPipe,
   SafePipe,
   XssPipe,
   AddSpacePipe,


### PR DESCRIPTION
#515

- [x] `decimalOrDash` Pipe eingeführt, zum einheitlichen Rendern der Dezimalzahlen
- [x] Die Dashes auf halbgeviert Striche geändert (– statt -)
- [ ] ~~Änderungen von https://github.com/bkd-mba-fbi/webapp-schulverwaltung/pull/627/ auch auf halbgeviert anpassen, wenn dieser gemerged ist.~~ → wurde bereits im anderen Branch gemacht