### PR TITLE
Fix search behavior #671

### DIFF
--- a/src/app/events/components/events-list/events-list.component.spec.ts
+++ b/src/app/events/components/events-list/events-list.component.spec.ts
@@ -13,10 +13,12 @@ describe("EventsListComponent", () => {
   let element: HTMLElement;
   let roles$: BehaviorSubject<Option<ReadonlyArray<string>>>;
   let setWithStudyCourses: jasmine.Spy;
+  let setSearchFields: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
     roles$ = new BehaviorSubject<Option<ReadonlyArray<string>>>(null);
     setWithStudyCourses = jasmine.createSpy("setWithStudyCourses");
+    setSearchFields = jasmine.createSpy("setSearchFields");
     stateServiceMock = {
       loading$: of(false),
       events$: of([buildEventEntry(1)]),
@@ -26,6 +28,7 @@ describe("EventsListComponent", () => {
         roles$.next(roles);
       },
       setWithStudyCourses,
+      setSearchFields,
       getEntries: () => of([buildEventEntry(1)]),
     } as unknown as EventsStateService;
 
@@ -55,18 +58,31 @@ describe("EventsListComponent", () => {
   });
 
   describe("withRatings", () => {
-    it("renders entry without ratings column", () => {
-      component.withRatings = false;
+    it("renders entry with ratings column it set to true", () => {
+      changeInput(component, "withRatings", true);
+      fixture.detectChanges();
+      expect(element.textContent).toContain("events.rating");
+    });
 
+    it("renders entry without ratings column it set to false", () => {
+      changeInput(component, "withRatings", false);
       fixture.detectChanges();
       expect(element.textContent).not.toContain("events.rating");
     });
 
-    it("renders entry with ratings column", () => {
-      component.withRatings = true;
-
+    it("includes 'evaluationText' in search fields it set to true", () => {
+      changeInput(component, "withRatings", true);
       fixture.detectChanges();
-      expect(element.textContent).toContain("events.rating");
+      expect(setSearchFields).toHaveBeenCalledWith([
+        "designation",
+        "evaluationText",
+      ]);
+    });
+
+    it("does not include in search fields it set to false", () => {
+      changeInput(component, "withRatings", false);
+      fixture.detectChanges();
+      expect(setSearchFields).toHaveBeenCalledWith(["designation"]);
     });
   });
 

--- a/src/app/events/components/events-list/events-list.component.ts
+++ b/src/app/events/components/events-list/events-list.component.ts
@@ -5,8 +5,17 @@ import { ResettableInputComponent } from "../../../shared/components/resettable-
 import { SpinnerComponent } from "../../../shared/components/spinner/spinner.component";
 import { LetDirective } from "../../../shared/directives/let.directive";
 import { StorageService } from "../../../shared/services/storage.service";
-import { EventsStateService } from "../../services/events-state.service";
+import {
+  EventEntry,
+  EventsStateService,
+} from "../../services/events-state.service";
 import { EventsListEntryComponent } from "../events-list-entry/events-list-entry.component";
+
+const BASE_SEARCH_FIELDS: ReadonlyArray<keyof EventEntry> = ["designation"];
+const WITH_RATINGS_SEARCH_FIELDS: ReadonlyArray<keyof EventEntry> = [
+  ...BASE_SEARCH_FIELDS,
+  "evaluationText",
+];
 
 @Component({
   selector: "bkd-events-list",
@@ -38,6 +47,14 @@ export class EventsListComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes["withStudyCourses"]) {
       this.state.setWithStudyCourses(changes["withStudyCourses"].currentValue);
+    }
+
+    if (changes["withRatings"]) {
+      this.state.setSearchFields(
+        changes["withRatings"].currentValue
+          ? WITH_RATINGS_SEARCH_FIELDS
+          : BASE_SEARCH_FIELDS,
+      );
     }
   }
 }

--- a/src/app/events/services/events-state.service.ts
+++ b/src/app/events/services/events-state.service.ts
@@ -53,6 +53,10 @@ type LinkType = "evaluation" | "eventdetail";
 export class EventsStateService {
   loading$ = this.loadingService.loading$;
 
+  private searchFields$ = new BehaviorSubject<ReadonlyArray<keyof EventEntry>>([
+    "designation",
+  ]);
+
   private searchSubject$ = new BehaviorSubject<string>("");
   search$ = this.searchSubject$.asObservable();
 
@@ -81,9 +85,11 @@ export class EventsStateService {
   );
 
   private events$ = this.getEvents().pipe(shareReplay(1));
-  private filteredEvents$ = combineLatest([this.events$, this.search$]).pipe(
-    map(spread(searchEntries)),
-  );
+  private filteredEvents$ = combineLatest([
+    this.events$,
+    this.searchFields$,
+    this.search$,
+  ]).pipe(map(spread(searchEntries)));
 
   constructor(
     private coursesRestService: CoursesRestService,
@@ -104,6 +110,10 @@ export class EventsStateService {
 
   setWithStudyCourses(enabled: boolean): void {
     this.withStudyCourses$.next(enabled);
+  }
+
+  setSearchFields(searchFields: ReadonlyArray<keyof EventEntry>): void {
+    this.searchFields$.next(searchFields);
   }
 
   getEntries(withRatings = false): Observable<ReadonlyArray<EventEntry>> {

--- a/src/app/open-absences/models/open-absences-entry.model.ts
+++ b/src/app/open-absences/models/open-absences-entry.model.ts
@@ -1,13 +1,12 @@
 import { format, startOfDay } from "date-fns";
 import { LessonPresence } from "src/app/shared/models/lesson-presence.model";
-import { Searchable } from "src/app/shared/utils/search";
 
 /**
  * Represents a grouping of LessonPresences by day/student. Make sure
  * you'll only instantiate it for absences on the same day and the
  * same student (may be multiple lessons).
  */
-export class OpenAbsencesEntry implements Searchable {
+export class OpenAbsencesEntry {
   readonly date: Date;
   readonly dateString: string;
   readonly studentId: number;

--- a/src/app/open-absences/services/open-absences.service.ts
+++ b/src/app/open-absences/services/open-absences.service.ts
@@ -19,6 +19,7 @@ import { searchEntries } from "src/app/shared/utils/search";
 import { SortCriteria } from "src/app/shared/utils/sort";
 import { Person } from "../../shared/models/person.model";
 import { toDesignationDateTimeTypeString } from "../../shared/utils/lesson-presences";
+import { OpenAbsencesEntry } from "../models/open-absences-entry.model";
 import {
   buildOpenAbsencesEntries,
   removeOpenAbsences,
@@ -26,6 +27,11 @@ import {
 } from "../utils/open-absences-entries";
 
 export type PrimarySortKey = "date" | "name";
+
+const SEARCH_FIELDS: ReadonlyArray<keyof OpenAbsencesEntry> = [
+  "studentFullName",
+  "studyClassNumber",
+];
 
 @Injectable()
 export class OpenAbsencesService implements IConfirmAbsencesService {
@@ -57,7 +63,7 @@ export class OpenAbsencesService implements IConfirmAbsencesService {
   );
 
   filteredEntries$ = combineLatest([this.sortedEntries$, this.search$]).pipe(
-    map(spread(searchEntries)),
+    map(([entries, term]) => searchEntries(entries, SEARCH_FIELDS, term)),
     shareReplay(1),
   );
 

--- a/src/app/presence-control/components/presence-control-list/presence-control-list.component.ts
+++ b/src/app/presence-control/components/presence-control-list/presence-control-list.component.ts
@@ -18,7 +18,6 @@ import { searchEntries } from "src/app/shared/utils/search";
 import { SpinnerComponent } from "../../../shared/components/spinner/spinner.component";
 import { LetDirective } from "../../../shared/directives/let.directive";
 import { PresenceTypesService } from "../../../shared/services/presence-types.service";
-import { spread } from "../../../shared/utils/function";
 import { PresenceControlEntry } from "../../models/presence-control-entry.model";
 import { PresenceControlBlockLessonService } from "../../services/presence-control-block-lesson.service";
 import {
@@ -29,6 +28,10 @@ import { PresenceControlBlockLessonComponent } from "../presence-control-block-l
 import { PresenceControlEntryComponent } from "../presence-control-entry/presence-control-entry.component";
 import { PresenceControlHeaderComponent } from "../presence-control-header/presence-control-header.component";
 import { PresenceControlIncidentComponent } from "../presence-control-incident/presence-control-incident.component";
+
+const SEARCH_FIELDS: ReadonlyArray<keyof PresenceControlEntry> = [
+  "studentFullName",
+];
 
 @Component({
   selector: "bkd-presence-control-list",
@@ -54,7 +57,10 @@ export class PresenceControlListComponent
   entries$ = combineLatest([
     this.state.presenceControlEntriesByGroup$,
     this.search$,
-  ]).pipe(map(spread(searchEntries)), shareReplay(1));
+  ]).pipe(
+    map(([entries, term]) => searchEntries(entries, SEARCH_FIELDS, term)),
+    shareReplay(1),
+  );
 
   private destroy$ = new Subject<void>();
 

--- a/src/app/presence-control/models/presence-control-entry.model.ts
+++ b/src/app/presence-control/models/presence-control-entry.model.ts
@@ -2,7 +2,6 @@ import { Settings } from "src/app/settings";
 import { DropDownItem } from "src/app/shared/models/drop-down-item.model";
 import { LessonPresence } from "src/app/shared/models/lesson-presence.model";
 import { PresenceType } from "src/app/shared/models/presence-type.model";
-import { Searchable } from "src/app/shared/utils/search";
 import { LessonAbsence } from "../../shared/models/lesson-absence.model";
 import {
   canChangePresenceType,
@@ -31,7 +30,7 @@ export function getPresenceCategoryIcon(category: PresenceCategory): string {
   }
 }
 
-export class PresenceControlEntry implements Searchable {
+export class PresenceControlEntry {
   readonly studentFullName: string;
   constructor(
     public lessonPresence: LessonPresence,

--- a/src/app/shared/utils/search.spec.ts
+++ b/src/app/shared/utils/search.spec.ts
@@ -1,8 +1,8 @@
 import { searchEntries } from "src/app/shared/utils/search";
 import { buildLessonPresence } from "src/spec-builders";
-import { PresenceControlEntry } from "../models/presence-control-entry.model";
+import { PresenceControlEntry } from "../../presence-control/models/presence-control-entry.model";
 
-describe("presence control entries utils", () => {
+describe("search utilities", () => {
   let bichsel: PresenceControlEntry;
   let frisch: PresenceControlEntry;
   let jenni: PresenceControlEntry;
@@ -13,24 +13,40 @@ describe("presence control entries utils", () => {
     jenni = buildPresenceControlEntry("Zoë Jenny");
   });
 
-  describe("searchPresenceControlEntries", () => {
+  describe("searchEntries", () => {
     it("returns all entries for empty term", () => {
-      const result = searchEntries([bichsel, frisch, jenni], "");
+      const result = searchEntries(
+        [bichsel, frisch, jenni],
+        ["studentFullName"],
+        "",
+      );
       expect(result).toEqual([bichsel, frisch, jenni]);
     });
 
     it("returns entries where student name matches term", () => {
-      const result = searchEntries([bichsel, frisch, jenni], "ch");
+      const result = searchEntries(
+        [bichsel, frisch, jenni],
+        ["studentFullName"],
+        "ch",
+      );
       expect(result).toEqual([bichsel, frisch]);
     });
 
     it("ignores case", () => {
-      const result = searchEntries([bichsel, frisch, jenni], "fri");
+      const result = searchEntries(
+        [bichsel, frisch, jenni],
+        ["studentFullName"],
+        "fri",
+      );
       expect(result).toEqual([frisch]);
     });
 
     it("normalizes special characters", () => {
-      const result = searchEntries([bichsel, frisch, jenni], "Zoe");
+      const result = searchEntries(
+        [bichsel, frisch, jenni],
+        ["studentFullName"],
+        "Zoe",
+      );
       expect(result).toEqual([jenni]);
     });
   });

--- a/src/app/shared/utils/search.ts
+++ b/src/app/shared/utils/search.ts
@@ -1,34 +1,30 @@
 import { deburr } from "lodash-es";
 
-export interface Searchable {
-  readonly studentFullName?: string;
-  readonly studyClassNumber?: string;
-  readonly designation?: string;
-  readonly evaluationText?: string;
-}
-
-export function searchEntries<T extends Searchable>(
+export function searchEntries<T>(
   entries: ReadonlyArray<T>,
+  searchFields: ReadonlyArray<keyof T>,
   term: string,
 ): ReadonlyArray<T> {
   if (!term) {
     return entries;
   }
 
-  return entries.filter(matchesEntry(term));
+  return entries.filter(matchesEntry(searchFields, term));
 }
 
-function matchesEntry(term: string): (entry: Searchable) => boolean {
-  const preparedTerm = normalizeSearchValue(term);
+function matchesEntry<T>(
+  searchFields: ReadonlyArray<keyof T>,
+  term: string,
+): (entry: T) => boolean {
+  const normalizedTerm = normalizeSearchValue(term);
   return (entry) =>
-    matches(entry.studentFullName, preparedTerm) ||
-    matches(entry.studyClassNumber, preparedTerm) ||
-    matches(entry.designation, preparedTerm) ||
-    matches(entry.evaluationText, preparedTerm);
+    searchFields.some((field) => matches(entry[field], normalizedTerm));
 }
 
-function matches(field: Maybe<string>, preparedTerm: string): boolean {
-  return field ? normalizeSearchValue(field).includes(preparedTerm) : false;
+function matches(value: unknown, normalizedTerm: string): boolean {
+  return value
+    ? normalizeSearchValue(String(value)).includes(normalizedTerm)
+    : false;
 }
 
 function normalizeSearchValue(value: string): string {


### PR DESCRIPTION
Siehe #671

Die durchsuchten Felder müssen nun jeweils von Fall zu Fall konkret definiert werden, kein `Searchable` Interface mehr.

Reproduzieren:
- Unter «Alle Fächer» soll bei einer Suche nach `w` oder `26` das Fach `English-S3, 27a` nicht mehr auftauchen.
- Unter «Tests und Bewertung» soll bei einer Suche nach `w` oder `26` das Fach `English-S3, 27a` weiterhin auftauchen.
- Die Suche in der «Präsenzkontrolle» und bei den «Offenen Absenzen» soll immer noch gleich funktionieren wie bisher.