### PR TITLE
Fix tests table layout & re-add sticky header #729 #721

### DIFF
--- a/src/app/events/components/grade/grade.component.scss
+++ b/src/app/events/components/grade/grade.component.scss
@@ -6,7 +6,7 @@
 }
 
 :host ::ng-deep select {
-  min-width: 13ch;
+  width: 127px; // 13ch
 }
 
 @include media-breakpoint-up(sm) {

--- a/src/app/events/components/grades/grade-select/grade-select.component.ts
+++ b/src/app/events/components/grades/grade-select/grade-select.component.ts
@@ -14,7 +14,7 @@ export class GradeSelectComponent {
   @Input() valueId: Option<number>; // the selected key from the options list
   @Input() gradeId: Option<number>; // the id of the grade itself
   @Input() disabled: boolean = false;
-  @Input() width: string = "13ch";
+  @Input() width: string = "127px"; // 13ch
 
   @Output() gradeIdSelected = new EventEmitter<{
     id: number;

--- a/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
+++ b/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
@@ -42,6 +42,7 @@
       ></bkd-test-table-header>
     </th>
   }
+  <th class="filler"></th>
 </tr>
 <tr>
   <th class="sticky student-name" (click)="state.sortBy('FullName')">
@@ -106,4 +107,5 @@
       </div>
     </th>
   }
+  <th class="filler"></th>
 </tr>

--- a/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
+++ b/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
@@ -44,7 +44,7 @@
   }
   <th class="filler"></th>
 </tr>
-<tr>
+<tr [ngClass]="{ 'test-point-grading': selectedTest?.IsPointGrading }">
   <th class="sticky student-name" (click)="state.sortBy('FullName')">
     <div class="d-flex">
       <div class="column-title">
@@ -90,7 +90,7 @@
     >
       <div class="d-flex">
         @if (test.IsPointGrading) {
-          <div class="column-title me-3 point-input-container">
+          <div class="column-title point-input-container me-2 me-md-3">
             <span (click)="state.sortBy(test)"
               >{{ "tests.points" | translate }}
             </span>

--- a/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
+++ b/src/app/events/components/test-edit-grades-header/test-edit-grades-header.component.html
@@ -44,7 +44,7 @@
   }
 </tr>
 <tr>
-  <th class="student-name" (click)="state.sortBy('FullName')">
+  <th class="sticky student-name" (click)="state.sortBy('FullName')">
     <div class="d-flex">
       <div class="column-title">
         {{ "tests.student.name" | translate }}
@@ -55,7 +55,7 @@
     </div>
   </th>
   <th
-    class="student-grade desktop"
+    class="sticky student-grade desktop"
     (click)="state.sortBy('FinalGrade')"
     [ngClass]="{ selected: selectedTest === undefined }"
   >
@@ -69,7 +69,7 @@
     </div>
   </th>
   <th
-    class="border-end student-average desktop"
+    class="border-end sticky student-average desktop"
     (click)="state.sortBy('TestsMean')"
   >
     <div class="d-flex">

--- a/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
@@ -52,6 +52,22 @@ td.student-grade {
   width: calc(var(--point-input-size) + 13ch + 3 * $spacer);
 }
 
+/**
+ * Column at the end of the table that eats up all the remaining space such that
+ * the all other (fixed-width) columns don't get stretched.
+ */
+th.filler,
+td.filler {
+  padding: 0;
+  width: auto;
+}
+@media (max-width: ($bkd-tests-mobile-breakpoint)) {
+  th.filler,
+  td.filler {
+    width: 0;
+  }
+}
+
 // Mobile view
 @media (max-width: ($bkd-tests-mobile-breakpoint)) {
   .desktop:not(.selected),

--- a/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
@@ -1,15 +1,26 @@
 @import "../../../../bootstrap-variables";
+@import "node_modules/bootstrap/scss/mixins";
 
 /**
  * Common table styles for the TestEditGradesComponent & the TestEditGradesHeaderComponent
  */
 
 :host {
-  --student-name-column-width: 225px;
-  --student-grade-column-width: 147px;
-  --student-average-column-width: 100px;
-  --test-grade-column-width: 300px;
+  --spacer: 16px;
+
   --point-input-size: 4em;
+  --grade-input-size: 127px; // 13ch
+  --points-grade-gap: 1rem;
+
+  --student-name-column-width: 225px;
+  --student-grade-column-width: calc(
+    var(--spacer) + var(--grade-input-size) + var(--spacer)
+  );
+  --student-average-column-width: 100px;
+  --test-grade-column-width: calc(
+    var(--spacer) + var(--point-input-size) + var(--points-grade-gap) +
+      var(--grade-input-size) + var(--spacer)
+  );
 
   --student-grade-column-offset: var(--student-name-column-width);
   --student-average-column-offset: calc(
@@ -30,6 +41,12 @@ $student-average-breakpoint: 1200px;
   }
 }
 
+@include media-breakpoint-down(md) {
+  :host {
+    --points-grade-gap: calc(0.5 * var(--spacer));
+  }
+}
+
 th,
 td {
   padding: $spacer;
@@ -46,10 +63,20 @@ td {
 }
 
 tr:not(.header-collapsible) th.test-grade,
-td.test-grade,
-th.student-grade,
-td.student-grade {
-  width: calc(var(--point-input-size) + 13ch + 3 * $spacer);
+td.test-grade {
+  width: var(--test-grade-column-width);
+  min-width: var(--test-grade-column-width);
+  max-width: var(--test-grade-column-width);
+}
+@media (max-width: ($bkd-tests-mobile-breakpoint)) {
+  tr:not(.header-collapsible):not(.test-point-grading) th.test-grade,
+  tr:not(.test-point-grading) th.student-grade,
+  table:not(.test-point-grading) td.test-grade,
+  table:not(.test-point-grading) td.student-grade {
+    width: calc(var(--spacer) + var(--grade-input-size) + var(--spacer));
+    min-width: calc(var(--spacer) + var(--grade-input-size) + var(--spacer));
+    max-width: calc(var(--spacer) + var(--grade-input-size) + var(--spacer));
+  }
 }
 
 /**
@@ -57,15 +84,21 @@ td.student-grade {
  * the all other (fixed-width) columns don't get stretched.
  */
 th.filler,
+.header-collapsible th.filler,
 td.filler {
   padding: 0;
   width: auto;
 }
 @media (max-width: ($bkd-tests-mobile-breakpoint)) {
   th.filler,
+  .header-collapsible th.filler,
   td.filler {
     width: 0;
   }
+}
+
+th.test-grade .column-title.point-input-container {
+  width: var(--point-input-size);
 }
 
 // Mobile view
@@ -98,6 +131,7 @@ td.filler {
   .student-name {
     flex: 1;
     display: block;
+    padding-right: 0;
   }
 
   .test-grade {
@@ -131,6 +165,7 @@ td.filler {
   }
 
   .test-grade {
+    width: var(--test-grade-column-width);
     min-width: var(--test-grade-column-width);
     max-width: var(--test-grade-column-width);
   }

--- a/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades-common.scss
@@ -18,14 +18,6 @@
   --test-columns-offset: calc(
     var(--student-average-column-offset) + var(--student-average-column-width)
   );
-  #stickyHeader {
-    display: none;
-  }
-  .scroll-test-table {
-    display: table-caption;
-    overflow-y: auto;
-    height: auto;
-  }
 }
 
 $student-name-width-breakpoint: 1000px;

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -92,6 +92,7 @@
               ></bkd-grade>
             </td>
           }
+          <td class="filler"></td>
         </tr>
       }
       <!-- course and test averages -->
@@ -132,6 +133,7 @@
             <bkd-average-grades [test]="test"></bkd-average-grades>
           </td>
         }
+        <td class="filler"></td>
       </tr>
     </tbody>
   </table>

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -10,7 +10,6 @@
     [stickyHeader]="stickyHeader"
   >
     <thead
-      style="display: block"
       bkdTestEditGradesHeader
       [selectedTest]="selectedTest"
       (publish)="publish($event)"
@@ -18,7 +17,6 @@
       #inlineHeader
     ></thead>
     <thead
-      id="stickyHeader"
       bkdTestEditGradesHeader
       [sticky]="true"
       [selectedTest]="selectedTest"
@@ -26,14 +24,14 @@
       (unpublish)="unpublish($event)"
       #stickyHeader
     ></thead>
-    <tbody id="scrollTestTable" class="scroll-test-table">
+    <tbody>
       @for (
         studentGrade of studentGrades;
         track studentGrade.student.Id;
         let studentGradeIndex = $index
       ) {
         <tr>
-          <td class="student-name">
+          <td class="sticky student-name">
             <a [routerLink]="['student', studentGrade.student.Id, 'grades']">
               <div>{{ studentGrade.student.FullName }}</div>
               <div class="student-average-inline">
@@ -43,7 +41,7 @@
             </a>
           </td>
           <td
-            class="student-grade"
+            class="sticky student-grade"
             [ngClass]="{ selected: selectedTest === undefined }"
           >
             @if (

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -5,6 +5,7 @@
 <div class="table-responsive-wrapper">
   <table
     class="table table-hover h-100"
+    [ngClass]="{ 'test-point-grading': selectedTest?.IsPointGrading }"
     bkdTestEditGradesHeaderSticky
     [inlineHeader]="inlineHeader"
     [stickyHeader]="stickyHeader"

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.scss
@@ -3,8 +3,6 @@
 @import "./test-edit-grades-common";
 
 tbody td.student-name {
-  padding-right: 0;
-
   &,
   * {
     white-space: nowrap;


### PR DESCRIPTION
Siehe #729 #721

- [x] Sticky Header (welcher im Rahmen von #728 deaktiviert wurde) wieder aktivieren
- [x] Spalten sollten eine fixe Breite haben → fixed Sticky Header Problem, siehe #728
- [x] Auf Mobile soll die Spalte mit den Punkten/Noten rechts aligniert werden, siehe #721
- [x] Tabellenüberschriften «Note» und «Punkte» sollen immer schön über den Feldern ausgerichtet sein.

Habe Screenshots von den Änderungen im Ticket hinzugefügt:
https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/729#issuecomment-2534789979