### PR TITLE
Student lists fixes #712 #713

### DIFF
--- a/src/app/events/components/events-students-course-entry/events-students-course-entry.component.html
+++ b/src/app/events/components/events-students-course-entry/events-students-course-entry.component.html
@@ -6,10 +6,10 @@
 ></bkd-avatar>
 <a
   class="name"
-  [title]="name()"
+  [title]="entry().name"
   [routerLink]="link()"
   [queryParams]="linkParams()"
-  >{{ name() }}</a
+  >{{ entry().name }}</a
 >
 <div class="study-class">
   {{ multipleStudyClasses() ? entry().studyClass : "" }}

--- a/src/app/events/components/events-students-course-entry/events-students-course-entry.component.spec.ts
+++ b/src/app/events/components/events-students-course-entry/events-students-course-entry.component.spec.ts
@@ -19,8 +19,7 @@ describe("EventsStudentsCourseEntryComponent", () => {
 
     fixture.componentRef.setInput("entry", {
       id: 1,
-      firstName: "Jane",
-      lastName: "Doe",
+      name: "Doe Jane",
       email: "jane.doe@example.com",
       studyClass: "26a",
       company: "Coop Genossenschaft",
@@ -31,9 +30,9 @@ describe("EventsStudentsCourseEntryComponent", () => {
 
   it("renders firstname/lastname with link to dossier including returnlink", () => {
     const link = element.querySelector<HTMLAnchorElement>("a.name");
-    expect(link?.textContent).toContain("Jane Doe");
+    expect(link?.textContent).toContain("Doe Jane");
     expect(link?.href).toContain(
-      "student/1/absences?returnparams=returnlink%3D%252Fevents%252Fcurrent",
+      "student/1/addresses?returnparams=returnlink%3D%252Fevents%252Fcurrent",
     );
   });
 

--- a/src/app/events/components/events-students-course-entry/events-students-course-entry.component.ts
+++ b/src/app/events/components/events-students-course-entry/events-students-course-entry.component.ts
@@ -21,14 +21,10 @@ export class EventsStudentsCourseEntryComponent {
   multipleStudyClasses = input(false);
   returnLink = input<Option<string>>(null);
 
-  name = computed<string>(
-    () => `${this.entry().firstName} ${this.entry().lastName}`,
-  );
-
   link = computed<RouterLink["routerLink"]>(() => [
     "student",
     this.entry().id,
-    "absences",
+    "addresses",
   ]);
   linkParams = computed<Params>(() => {
     const returnlink = this.returnLink();

--- a/src/app/events/components/events-students-course-list/events-students-course-list.component.scss
+++ b/src/app/events/components/events-students-course-list/events-students-course-list.component.scss
@@ -7,7 +7,7 @@
 
 section.list {
   width: calc(100% + 1px); // Hide right border
-  margin-top: 2 * $spacer;
+  margin-top: 1 * $spacer;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 }

--- a/src/app/events/components/events-students-header/events-students-header.component.html
+++ b/src/app/events/components/events-students-header/events-students-header.component.html
@@ -15,7 +15,7 @@
 <bkd-resettable-input
   class="search"
   [value]="searchTerm()"
-  [placeholder]="'events-students.search-by-name' | translate"
+  [placeholder]="'events-students.search-placeholder' | translate"
   [label]="'events-students.search' | translate"
   (valueChange)="searchTerm.set($event)"
 ></bkd-resettable-input>

--- a/src/app/events/components/events-students-header/events-students-header.component.scss
+++ b/src/app/events/components/events-students-header/events-students-header.component.scss
@@ -1,5 +1,9 @@
 @import "../../../../bootstrap-variables";
 
+h1 {
+  margin-bottom: 0;
+}
+
 .search {
   margin-top: $spacer;
   display: flex;

--- a/src/app/events/components/events-students-list/events-students-list.component.spec.ts
+++ b/src/app/events/components/events-students-list/events-students-list.component.spec.ts
@@ -38,32 +38,28 @@ describe("EventsStudentsListComponent", () => {
               const entries: ReadonlyArray<StudentEntry> = [
                 {
                   id: 10,
-                  firstName: "Paul",
-                  lastName: "McCartney",
+                  name: "McCartney Paul",
                   email: "paul.mccartney@example.com",
                   studyClass: "26a",
                   company: "Apple Records – Abbey Road Studios",
                 },
                 {
                   id: 20,
-                  firstName: "John",
-                  lastName: "Lennon",
+                  name: "Lennon John",
                   email: "john.lennon@example.com",
                   studyClass: "26a",
                   company: undefined,
                 },
                 {
                   id: 30,
-                  firstName: "George",
-                  lastName: "Harrison",
+                  name: "Harrison George",
                   email: "george.harrison@example.com",
                   studyClass: "26c",
                   company: undefined,
                 },
                 {
                   id: 40,
-                  firstName: "Ringo",
-                  lastName: "Starr",
+                  name: "Starr Ringo",
                   email: "ringo.starr@example.com",
                   studyClass: "26c",
                   company: undefined,
@@ -104,10 +100,10 @@ describe("EventsStudentsListComponent", () => {
         element.querySelector("bkd-events-students-course-list"),
       ).not.toBeNull();
       expect(element.querySelector("h1")?.textContent).toContain("English-S3");
-      expect(element.textContent).toContain("Paul McCartney");
-      expect(element.textContent).toContain("John Lennon");
-      expect(element.textContent).toContain("George Harrison");
-      expect(element.textContent).toContain("Ringo Starr");
+      expect(element.textContent).toContain("McCartney Paul");
+      expect(element.textContent).toContain("Lennon John");
+      expect(element.textContent).toContain("Harrison George");
+      expect(element.textContent).toContain("Starr Ringo");
     });
 
     it("renders placeholder if no entries are available", () => {
@@ -129,10 +125,10 @@ describe("EventsStudentsListComponent", () => {
         element.querySelector("bkd-events-students-study-course-list"),
       ).not.toBeNull();
       expect(element.querySelector("h1")?.textContent).toContain("English-S3");
-      expect(element.textContent).toContain("Paul McCartney");
-      expect(element.textContent).toContain("John Lennon");
-      expect(element.textContent).toContain("George Harrison");
-      expect(element.textContent).toContain("Ringo Starr");
+      expect(element.textContent).toContain("McCartney Paul");
+      expect(element.textContent).toContain("Lennon John");
+      expect(element.textContent).toContain("Harrison George");
+      expect(element.textContent).toContain("Starr Ringo");
     });
 
     it("renders placeholder if no entries are available", () => {

--- a/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.html
+++ b/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.html
@@ -1,4 +1,4 @@
 <a class="name" [routerLink]="link()" [queryParams]="linkParams()">{{
-  name()
+  entry().name
 }}</a>
 <div class="status">{{ entry().status }}</div>

--- a/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.spec.ts
+++ b/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.spec.ts
@@ -17,8 +17,7 @@ describe("EventsStudentsStudyCourseEntryComponent", () => {
     element = fixture.debugElement.nativeElement;
     fixture.componentRef.setInput("entry", {
       id: 1,
-      firstName: "Jane",
-      lastName: "Doe",
+      name: "Doe Jane",
       email: "jane.doe@example.com",
       studyClasses: ["26a", "26c"],
       company: "Coop Genossenschaft",
@@ -33,7 +32,7 @@ describe("EventsStudentsStudyCourseEntryComponent", () => {
 
   it("renders firstname/lastname with link to dossier including returnlink", () => {
     const link = element.querySelector<HTMLAnchorElement>("a.name");
-    expect(link?.textContent).toBe("Jane Doe");
+    expect(link?.textContent).toBe("Doe Jane");
     expect(link?.href).toContain(
       "student/1/absences?returnparams=returnlink%3D%252Fevents%252Fcurrent",
     );

--- a/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.ts
+++ b/src/app/events/components/events-students-study-course-entry/events-students-study-course-entry.component.ts
@@ -19,9 +19,6 @@ export class EventsStudentsStudyCourseEntryComponent {
   entry = input.required<StudentEntry>();
   returnLink = input<Option<string>>(null);
 
-  name = computed<string>(
-    () => `${this.entry().firstName} ${this.entry().lastName}`,
-  );
   link = computed<RouterLink["routerLink"]>(() => [
     "student",
     this.entry().id,

--- a/src/app/events/components/events-students-study-course-list/events-students-study-course-list.component.scss
+++ b/src/app/events/components/events-students-study-course-list/events-students-study-course-list.component.scss
@@ -4,12 +4,7 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  border-top: 1px solid $border-color;
   border-bottom: 2px solid $border-color;
-}
-
-section.list {
-  margin-top: 2 * $spacer;
 }
 
 .name {

--- a/src/app/events/components/events-students-study-course-list/events-students-study-course-list.component.ts
+++ b/src/app/events/components/events-students-study-course-list/events-students-study-course-list.component.ts
@@ -43,6 +43,6 @@ export class EventsStudentsStudyCourseListComponent {
   getSortDirectionCharacter(
     sortCriteria: SortCriteria<PrimarySortKey>,
   ): string {
-    return sortCriteria.ascending ? "↓" : "↑";
+    return sortCriteria.ascending ? "↑" : "↓";
   }
 }

--- a/src/app/events/services/events-students-state.service.spec.ts
+++ b/src/app/events/services/events-students-state.service.spec.ts
@@ -253,32 +253,28 @@ describe("EventsStudentsStateService", () => {
         const expected = [
           {
             id: 10,
-            firstName: "Paul",
-            lastName: "McCartney",
+            name: "McCartney Paul",
             email: "paul.mccartney@example.com",
             studyClass: "26a",
             company: "Apple Records – Abbey Road Studios",
           },
           {
             id: 20,
-            firstName: "John",
-            lastName: "Lennon",
+            name: "Lennon John",
             email: "john.lennon@example.com",
             studyClass: "26a",
             company: undefined,
           },
           {
             id: 30,
-            firstName: "George",
-            lastName: "Harrison",
+            name: "Harrison George",
             email: "george.harrison@example.com",
             studyClass: "26c",
             company: undefined,
           },
           {
             id: 40,
-            firstName: "Ringo",
-            lastName: "Starr",
+            name: "Starr Ringo",
             email: "ringo.starr@example.com",
             studyClass: "26c",
             company: undefined,
@@ -287,10 +283,10 @@ describe("EventsStudentsStateService", () => {
 
         expect(service.entries()).toEqual(expected);
         expect(service.sortedEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
         expect(service.filteredEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
       });
 
@@ -298,67 +294,75 @@ describe("EventsStudentsStateService", () => {
         service.searchTerm.set("pau");
         TestBed.flushEffects();
 
-        const entries = service
-          .sortedEntries()
-          .map(({ firstName }) => firstName);
-        expect(entries).toEqual(["George", "John", "Paul", "Ringo"]);
+        const entries = service.sortedEntries().map(({ name }) => name);
+        expect(entries).toEqual([
+          "Harrison George",
+          "Lennon John",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
 
-        const filtered = service
-          .filteredEntries()
-          .map(({ firstName }) => firstName);
-        expect(filtered).toEqual(["Paul"]);
+        const filtered = service.filteredEntries().map(({ name }) => name);
+        expect(filtered).toEqual(["McCartney Paul"]);
       });
 
       it("returns filtered entries for matching lastname", () => {
         service.searchTerm.set("ar");
         TestBed.flushEffects();
 
-        const entries = service
-          .sortedEntries()
-          .map(({ firstName }) => firstName);
-        expect(entries).toEqual(["George", "John", "Paul", "Ringo"]);
+        const entries = service.sortedEntries().map(({ name }) => name);
+        expect(entries).toEqual([
+          "Harrison George",
+          "Lennon John",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
 
-        const filtered = service
-          .filteredEntries()
-          .map(({ firstName }) => firstName);
-        expect(filtered).toEqual(["George", "Paul", "Ringo"]);
+        const filtered = service.filteredEntries().map(({ name }) => name);
+        expect(filtered).toEqual([
+          "Harrison George",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
       });
 
       it("returns filtered entries for matching company", () => {
         service.searchTerm.set("abbey");
         TestBed.flushEffects();
 
-        const entries = service
-          .sortedEntries()
-          .map(({ firstName }) => firstName);
-        expect(entries).toEqual(["George", "John", "Paul", "Ringo"]);
+        const entries = service.sortedEntries().map(({ name }) => name);
+        expect(entries).toEqual([
+          "Harrison George",
+          "Lennon John",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
 
-        const filtered = service
-          .filteredEntries()
-          .map(({ firstName }) => firstName);
-        expect(filtered).toEqual(["Paul"]);
+        const filtered = service.filteredEntries().map(({ name }) => name);
+        expect(filtered).toEqual(["McCartney Paul"]);
       });
 
       it("returns filtered entries for matching class", () => {
         service.searchTerm.set("26c");
         TestBed.flushEffects();
 
-        const entries = service
-          .sortedEntries()
-          .map(({ firstName }) => firstName);
-        expect(entries).toEqual(["George", "John", "Paul", "Ringo"]);
+        const entries = service.sortedEntries().map(({ name }) => name);
+        expect(entries).toEqual([
+          "Harrison George",
+          "Lennon John",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
 
-        const filtered = service
-          .filteredEntries()
-          .map(({ firstName }) => firstName);
-        expect(filtered).toEqual(["George", "Ringo"]);
+        const filtered = service.filteredEntries().map(({ name }) => name);
+        expect(filtered).toEqual(["Harrison George", "Starr Ringo"]);
       });
     });
 
     describe("mailtoLink", () => {
       it("is the mailto: link value with all email addresses comma-separated", () => {
         expect(service.mailtoLink()).toBe(
-          "mailto:paul.mccartney@example.com,john.lennon@example.com,george.harrison@example.com,ringo.starr@example.com",
+          "mailto:paul.mccartney@example.com;john.lennon@example.com;george.harrison@example.com;ringo.starr@example.com",
         );
       });
     });
@@ -400,40 +404,40 @@ describe("EventsStudentsStateService", () => {
         const expected = [
           {
             id: 10,
-            firstName: "Paul",
-            lastName: "McCartney",
+            name: "McCartney Paul",
             email: "paul.mccartney@example.com",
             status: "Angemeldet",
+            company: "Apple Records – Abbey Road Studios",
           },
           {
             id: 20,
-            firstName: "John",
-            lastName: "Lennon",
+            name: "Lennon John",
             email: "john.lennon@example.com",
             status: "Aufgenommen",
+            company: undefined,
           },
           {
             id: 30,
-            firstName: "George",
-            lastName: "Harrison",
+            name: "Harrison George",
             email: "george.harrison@example.com",
             status: "Aufgenommen",
+            company: undefined,
           },
           {
             id: 40,
-            firstName: "Ringo",
-            lastName: "Starr",
+            name: "Starr Ringo",
             email: "ringo.starr@example.com",
             status: "Aufgenommen",
+            company: undefined,
           },
         ];
 
         expect(service.entries()).toEqual(expected);
         expect(service.sortedEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
         expect(service.filteredEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
       });
     });
@@ -441,7 +445,7 @@ describe("EventsStudentsStateService", () => {
     describe("mailtoLink", () => {
       it("is the mailto: link value with all email addresses comma-separated", () => {
         expect(service.mailtoLink()).toBe(
-          "mailto:paul.mccartney@example.com,john.lennon@example.com,george.harrison@example.com,ringo.starr@example.com",
+          "mailto:paul.mccartney@example.com;john.lennon@example.com;george.harrison@example.com;ringo.starr@example.com",
         );
       });
     });
@@ -483,29 +487,25 @@ describe("EventsStudentsStateService", () => {
         const expected = [
           {
             id: 10,
-            firstName: "Paul",
-            lastName: "McCartney",
+            name: "McCartney Paul",
             email: "paul.mccartney@example.com",
             status: "Angemeldet",
           },
           {
             id: 20,
-            firstName: "John",
-            lastName: "Lennon",
+            name: "Lennon John",
             email: "john.lennon@example.com",
             status: "Aufgenommen",
           },
           {
             id: 30,
-            firstName: "George",
-            lastName: "Harrison",
+            name: "Harrison George",
             email: "george.harrison@example.com",
             status: "Aufgenommen",
           },
           {
             id: 40,
-            firstName: "Ringo",
-            lastName: "Starr",
+            name: "Starr Ringo",
             email: "ringo.starr@example.com",
             status: "Aufgenommen",
           },
@@ -513,24 +513,30 @@ describe("EventsStudentsStateService", () => {
 
         expect(service.entries()).toEqual(expected);
         expect(service.sortedEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
         expect(service.filteredEntries()).toEqual(
-          expected.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+          expected.sort((a, b) => a.name.localeCompare(b.name)),
         );
       });
 
       it("changes the sort direction", () => {
-        expect(
-          service.sortedEntries().map(({ firstName }) => firstName),
-        ).toEqual(["George", "John", "Paul", "Ringo"]);
+        expect(service.sortedEntries().map(({ name }) => name)).toEqual([
+          "Harrison George",
+          "Lennon John",
+          "McCartney Paul",
+          "Starr Ringo",
+        ]);
 
         service.toggleSort();
         TestBed.flushEffects();
 
-        expect(
-          service.sortedEntries().map(({ firstName }) => firstName),
-        ).toEqual(["Ringo", "Paul", "John", "George"]);
+        expect(service.sortedEntries().map(({ name }) => name)).toEqual([
+          "Starr Ringo",
+          "McCartney Paul",
+          "Lennon John",
+          "Harrison George",
+        ]);
       });
     });
 

--- a/src/app/events/utils/events-students.ts
+++ b/src/app/events/utils/events-students.ts
@@ -24,8 +24,7 @@ export function convertCourseToStudentEntries(course: Course): StudentEntries {
       (student) =>
         ({
           id: student.Id,
-          firstName: student.FirstName,
-          lastName: student.LastName,
+          name: `${student.LastName} ${student.FirstName}`,
           email: student.DisplayEmail ?? undefined,
         }) satisfies StudentEntry,
     ) ?? [];
@@ -71,8 +70,7 @@ export function convertPersonsToStudentEntries(
       (person) =>
         ({
           id: person.Id,
-          firstName: person.FirstName,
-          lastName: person.LastName,
+          name: `${person.LastName} ${person.FirstName}`,
           email: person.DisplayEmail ?? undefined,
           status: subscriptions.find((s) => s.PersonId === person.Id)?.Status,
         }) satisfies StudentEntry,

--- a/src/app/presence-control/components/presence-control-list/presence-control-list.component.scss
+++ b/src/app/presence-control/components/presence-control-list/presence-control-list.component.scss
@@ -10,18 +10,14 @@ bkd-presence-control-entry {
  * Grid view mode (default layout is list view mode)
  */
 .entries.view-mode-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax($bkd-presence-control-entry-min-width, 1fr)
+  );
 
   > * {
-    width: 100%;
-
-    @for $i from 1 through 6 {
-      @media (min-width: $bkd-presence-control-entry-min-width * $i) {
-        width: percentage(math.div(1, $i));
-        border-right: 1px solid $border-color;
-      }
-    }
+    border-right: 1px solid $border-color;
   }
 }
 

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -258,7 +258,7 @@
     "registration": "{{count}} Anmeldung",
     "registrations": "{{count}} Anmeldungen",
     "search": "Suchen",
-    "search-by-name": "Name suchen...",
+    "search-placeholder": "Suchen...",
     "list": {
       "header": {
         "name": "Name"

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -258,7 +258,7 @@
     "registration": "{{count}} inscription",
     "registrations": "{{count}} inscriptions",
     "search": "Rechercher",
-    "search-by-name": "Rechercher un nom...",
+    "search-placeholder": "Rechercher...",
     "list": {
       "header": {
         "name": "Nom"


### PR DESCRIPTION
Siehe #712 #713

Fach-/Klassenliste:

- [ ] Wenn ich von "Aktuelle Fächer" auf die Fach-/Klassenliste gelange, wird in der Navigation unter "Unterricht" der Link "Tests und Bewertung" als aktiv angezeigt - falsche Verlinkung?
  - → Eigener PR
- [x] Die Namen sind falsch dargestellt: Vorname Nachname statt Nachname Vornamen. Damit stimmt auch die Sortierung (alphabetisch nach Nachname Vorname) nicht.
        Fachliste: ParticipatingStudents => FullName
        Klassenliste: /Persons => FullName
- [x] Klick auf den Namen sollte wohl am besten auf das Dossier > Adresse führen (nicht Absenzen; Spezifikation implizit falsch)
- [x] Layout: Die Anzahl Anmeldungen hat zu viel Abstand zur Bezeichnung Fach/Klasse => Bitte so wie bei den Tests.
- [x] Layout: Das Suchfeld hat zu viel Abstand zur Liste darunter => Bitte so wie bei der Präsenzkontrolle.
- [x] Breakpoints: Diese stimmen nicht exakt mit der Präsenzkontrolle überein, wenige Pixel Abweichung - weshalb ist das so? (oder bin ich zu pingelig ;)
- [x] Mail an alle: Kommatrennung funktioniert bei mir mit Outlook nicht, wird als 1 E-Mail-Adresse angeschaut => Bitte mit Semikolon trennen.
- [x] Klassenliste: Der Lehrbetrieb wird nicht angezeigt.

Studengangsliste:

- [x] Platzhalter im Suchfeld falsch: Richtig ist "Name oder Status suchen" (vgl. Mockup)
- [x] Gleiches Problem wie bei
https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/712 : Sortierung falsch (Vorname Nachname) => Sortierung bitte nach FullName (Nachname Vornamen)
- [x] Richtung des Pfeils bei Sortierung vollständiger Name: A-Z (aufsteigend) => Pfeil nach oben
image
