### PR TITLE
Evaluation link must not be client-side routed #771

### DIFF
--- a/src/app/events/components/events-list-entry/events-list-entry.component.html
+++ b/src/app/events/components/events-list-entry/events-list-entry.component.html
@@ -30,7 +30,7 @@
       </a>
     }
     @if (event().evaluationLink) {
-      <a class="d-flex" [routerLink]="event().evaluationLink">
+      <a class="d-flex" [href]="event().evaluationLink">
         <i class="material-icons">arrow_right_alt</i>
         <span class="ps-1">{{ event().evaluationText }} </span>
       </a>


### PR DESCRIPTION
Siehe #771

Im Portal zeigt der Evaluation Link immer noch auf eine andere App, wir dürfen also nicht Client-side Routing machen:

https://github.com/bkd-mba-fbi/evento-portal/blob/main/public/apps/webapp-schulverwaltung/settings.js#L249

(kann man erst richtig testen wenn integriert im Portal)