### PR TITLE
Feature/769 final grade disabled

### DIFF
--- a/src/app/events/components/grade/grade.component.html
+++ b/src/app/events/components/grade/grade.component.html
@@ -9,7 +9,7 @@
           step="0.01"
           min="0"
           max="{{ maxPoints }}"
-          [disabled]="grade.test.IsPublished"
+          [disabled]="grade.test.IsPublished || hasFinalGrade"
           tabindex="{{ tabIndex }}"
           [ngModel]="grade.kind === 'grade' ? grade.result.Points : null"
           (ngModelChange)="onPointsChange(points.value)"

--- a/src/app/events/components/grade/grade.component.spec.ts
+++ b/src/app/events/components/grade/grade.component.spec.ts
@@ -5,12 +5,11 @@ import {
   fakeAsync,
   tick,
 } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { of } from "rxjs";
-import { DropDownItem } from "src/app/shared/models/drop-down-item.model";
 import { GradeKind, NoResult } from "src/app/shared/models/student-grades";
 import { Student } from "src/app/shared/models/student.model";
 import { Result, Test } from "src/app/shared/models/test.model";
-import { byTestId } from "src/specs/utils";
 import {
   buildResult,
   buildStudent,
@@ -53,36 +52,21 @@ describe("GradeComponent", () => {
     component = fixture.componentInstance;
     component.student = student;
     debugElement = fixture.debugElement;
+
+    component.gradeOptions = [
+      { Key: 1, Value: "1.0" },
+      { Key: 2, Value: "2.0" },
+      { Key: 3, Value: "3.0" },
+      { Key: 4, Value: "4.0" },
+      { Key: 5, Value: "5.0" },
+      { Key: 6, Value: "6.0" },
+    ];
   });
 
-  it("should create", () => {
-    // given
-    component.grade = {
-      kind: "grade",
-      result,
-      test,
-    };
-    // when
-    fixture.detectChanges();
-
-    // then
-    expect(component).toBeTruthy();
-  });
-
-  describe("tests without point grading", () => {
-    let gradingScaleOptions: DropDownItem[];
+  describe("grade grading test", () => {
     let grade: GradeKind;
 
     beforeEach(() => {
-      gradingScaleOptions = [
-        { Key: 1, Value: "1.0" },
-        { Key: 2, Value: "2.0" },
-        { Key: 3, Value: "3.0" },
-        { Key: 4, Value: "4.0" },
-        { Key: 5, Value: "5.0" },
-        { Key: 6, Value: "6.0" },
-      ];
-
       grade = {
         kind: "grade",
         result,
@@ -93,79 +77,65 @@ describe("GradeComponent", () => {
       grade.result.GradeId = 4;
     });
 
-    it("should show grading options and select grade from options", (done) => {
-      // given
+    it("renders grade select with grading options and grade selected", async () => {
       component.grade = grade;
-      component.gradeOptions = gradingScaleOptions;
-
-      // when
       fixture.detectChanges();
 
-      // then
-
-      const select = debugElement.query(byTestId("grade-select")).nativeElement
-        .firstChild;
-
-      expect(select.options.length).toBe(7);
-      expect(select.options[0].textContent?.trim()).toBe("");
-      expect(select.options[1].textContent?.trim()).toBe("1.0");
-      expect(select.options[2].textContent?.trim()).toBe("2.0");
-      expect(select.options[3].textContent?.trim()).toBe("3.0");
-      expect(select.options[4].textContent?.trim()).toBe("4.0");
-      expect(select.options[5].textContent?.trim()).toBe("5.0");
-      expect(select.options[6].textContent?.trim()).toBe("6.0");
-
-      void fixture.whenStable().then(() => {
-        expect(select.selectedIndex).toBe(4);
-        done();
-      });
+      const select = await queryGradeSelect();
+      expect(select).not.toBeNull();
+      expect(select!.options.length).toBe(7);
+      expect(select!.options[0].textContent?.trim()).toBe("");
+      expect(select!.options[1].textContent?.trim()).toBe("1.0");
+      expect(select!.options[2].textContent?.trim()).toBe("2.0");
+      expect(select!.options[3].textContent?.trim()).toBe("3.0");
+      expect(select!.options[4].textContent?.trim()).toBe("4.0");
+      expect(select!.options[5].textContent?.trim()).toBe("5.0");
+      expect(select!.options[6].textContent?.trim()).toBe("6.0");
+      expect(select!.selectedIndex).toBe(4);
     });
 
-    it("should show grading options without selection if there is no result yet", (done) => {
-      // given
+    it("renders grade select with grading options and no value selected for a 'no-result' grade", async () => {
       const noResult: NoResult = {
         kind: "no-result",
         test,
       };
-
       component.grade = noResult;
-      component.gradeOptions = gradingScaleOptions;
-
-      // when
       fixture.detectChanges();
 
-      // then
-      const select = debugElement.query(byTestId("grade-select")).nativeElement
-        .firstChild;
-
-      expect(select.options.length).toBe(7);
-      expect(select.options[0].textContent.trim()).toBe("");
-      expect(select.options[1].textContent.trim()).toBe("1.0");
-      expect(select.options[2].textContent.trim()).toBe("2.0");
-      expect(select.options[3].textContent.trim()).toBe("3.0");
-      expect(select.options[4].textContent.trim()).toBe("4.0");
-      expect(select.options[5].textContent.trim()).toBe("5.0");
-      expect(select.options[6].textContent.trim()).toBe("6.0");
-
-      void fixture.whenStable().then(() => {
-        expect(select.selectedIndex).toBe(0);
-        done();
-      });
+      const select = await queryGradeSelect();
+      expect(select).not.toBeNull();
+      expect(select!.options.length).toBe(7);
+      expect(select!.options[0].textContent?.trim()).toBe("");
+      expect(select!.options[1].textContent?.trim()).toBe("1.0");
+      expect(select!.options[2].textContent?.trim()).toBe("2.0");
+      expect(select!.options[3].textContent?.trim()).toBe("3.0");
+      expect(select!.options[4].textContent?.trim()).toBe("4.0");
+      expect(select!.options[5].textContent?.trim()).toBe("5.0");
+      expect(select!.options[6].textContent?.trim()).toBe("6.0");
+      expect(select!.selectedIndex).toBe(0);
     });
 
-    it("saves grade if changed", fakeAsync(() => {
+    it("does not render points input", async () => {
       component.grade = grade;
-      component.gradeOptions = gradingScaleOptions;
+      fixture.detectChanges();
+
+      const input = await queryPointsInput();
+      expect(input).toBeNull();
+    });
+
+    it("saves grade on change", fakeAsync(async () => {
+      component.grade = grade;
       component.ngOnInit();
       fixture.detectChanges();
+
       tick(1250);
       expect(mockTestService.optimisticallyUpdateGrade).not.toHaveBeenCalled();
       expect(mockTestService.saveGrade).not.toHaveBeenCalled();
 
-      const select = debugElement.query(byTestId("grade-select")).nativeElement
-        .firstChild;
-      select.selectedIndex = 3;
-      select.dispatchEvent(new Event("change"));
+      const select = await queryGradeSelect();
+      expect(select).not.toBeNull();
+      select!.selectedIndex = 3;
+      select!.dispatchEvent(new Event("change"));
       fixture.detectChanges();
       expect(mockTestService.optimisticallyUpdateGrade).toHaveBeenCalled();
       expect(mockTestService.saveGrade).not.toHaveBeenCalled();
@@ -175,66 +145,97 @@ describe("GradeComponent", () => {
       const args = mockTestService.saveGrade.calls.mostRecent().args[0];
       expect("gradeId" in args && args.gradeId).toBe(3);
     }));
+
+    describe("grade select disabled state", () => {
+      beforeEach(() => {
+        component.grade = grade;
+      });
+
+      it("is enabled for non-published test without final grade", async () => {
+        grade.test.IsPublished = false;
+        component.hasFinalGrade = false;
+        fixture.detectChanges();
+
+        const select = await queryGradeSelect();
+        expect(select?.disabled).toBe(false);
+      });
+
+      it("is disabled for published test without final grade", async () => {
+        grade.test.IsPublished = true;
+        component.hasFinalGrade = false;
+        fixture.detectChanges();
+
+        const select = await queryGradeSelect();
+        expect(select?.disabled).toBe(true);
+      });
+
+      it("is disabled for non-published test with final grade", async () => {
+        grade.test.IsPublished = false;
+        component.hasFinalGrade = true;
+        fixture.detectChanges();
+
+        const select = await queryGradeSelect();
+        expect(select?.disabled).toBe(true);
+      });
+
+      it("is disabled for published test with final grade", async () => {
+        grade.test.IsPublished = true;
+        component.hasFinalGrade = true;
+        fixture.detectChanges();
+
+        const select = await queryGradeSelect();
+        expect(select?.disabled).toBe(true);
+      });
+    });
   });
 
-  describe("tests with point gradings", () => {
-    it("should create with noResult", () => {
-      // given
+  describe("points grading test", () => {
+    let grade: GradeKind;
+
+    beforeEach(() => {
+      grade = {
+        kind: "grade",
+        result,
+        test,
+      };
+      test.IsPointGrading = true;
+    });
+
+    it("renders points input with empty value for 'no-result' grade", async () => {
       const noResult: NoResult = {
         kind: "no-result",
         test,
       };
-
-      noResult.test.IsPointGrading = true;
       component.grade = noResult;
-
-      // when
       fixture.detectChanges();
 
-      expectPointsInputValue(debugElement, "");
+      const input = await queryPointsInput();
+      expect(input?.value).toBe("");
     });
 
-    it("should show points in input field", (done) => {
-      // given
-      const grade: GradeKind = {
-        kind: "grade",
-        result,
-        test,
-      };
-
-      grade.test.IsPointGrading = true;
+    it("renders points input with points value from result", async () => {
       grade.result.Points = 11;
-
-      // when
       component.grade = grade;
       fixture.detectChanges();
 
-      // then
-
-      void fixture.whenStable().then(() => {
-        expectPointsInputValue(debugElement, "11");
-        done();
-      });
+      const input = await queryPointsInput();
+      expect(input?.value).toBe("11");
     });
 
-    it("saves points if changed", fakeAsync(() => {
-      const grade: GradeKind = {
-        kind: "grade",
-        result,
-        test,
-      };
-      grade.test.IsPointGrading = true;
+    it("saves points on change", fakeAsync(async () => {
       grade.result.Points = 11;
       component.grade = grade;
       component.ngOnInit();
       fixture.detectChanges();
+
       tick(1250);
       expect(mockTestService.optimisticallyUpdateGrade).not.toHaveBeenCalled();
       expect(mockTestService.saveGrade).not.toHaveBeenCalled();
 
-      const input = debugElement.query(byTestId("point-input")).nativeElement;
-      input.value = 13;
-      input.dispatchEvent(new Event("input"));
+      const input = await queryPointsInput();
+      expect(input).not.toBeNull();
+      input!.value = "13";
+      input!.dispatchEvent(new Event("input"));
       fixture.detectChanges();
       expect(mockTestService.optimisticallyUpdateGrade).toHaveBeenCalled();
       expect(mockTestService.saveGrade).not.toHaveBeenCalled();
@@ -244,83 +245,150 @@ describe("GradeComponent", () => {
       const args = mockTestService.saveGrade.calls.mostRecent().args[0];
       expect("points" in args && args.points).toBe(13);
     }));
+
+    describe("points input disabled state", () => {
+      beforeEach(() => {
+        component.grade = grade;
+      });
+
+      it("is enabled for non-published test without final grade", async () => {
+        grade.test.IsPublished = false;
+        component.hasFinalGrade = false;
+        fixture.detectChanges();
+
+        const input = await queryPointsInput();
+        expect(input?.disabled).toBe(false);
+      });
+
+      it("is disabled for published test without final grade", async () => {
+        grade.test.IsPublished = true;
+        component.hasFinalGrade = false;
+        fixture.detectChanges();
+
+        const input = await queryPointsInput();
+        expect(input?.disabled).toBe(true);
+      });
+
+      it("is disabled for non-published test with final grade", async () => {
+        grade.test.IsPublished = false;
+        component.hasFinalGrade = true;
+        fixture.detectChanges();
+
+        const input = await queryPointsInput();
+        expect(input?.disabled).toBe(true);
+      });
+
+      it("is disabled for published test with final grade", async () => {
+        grade.test.IsPublished = true;
+        component.hasFinalGrade = true;
+        fixture.detectChanges();
+
+        const input = await queryPointsInput();
+        expect(input?.disabled).toBe(true);
+      });
+    });
+
+    describe("grade select disabled state", () => {
+      beforeEach(() => {
+        component.grade = grade;
+      });
+
+      describe("with points defined", () => {
+        beforeEach(() => {
+          grade.result.Points = null;
+        });
+
+        it("is enabled for non-published test without final grade", async () => {
+          grade.test.IsPublished = false;
+          component.hasFinalGrade = false;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(false);
+        });
+
+        it("is disabled for published test without final grade", async () => {
+          grade.test.IsPublished = true;
+          component.hasFinalGrade = false;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+
+        it("is disabled for non-published test with final grade", async () => {
+          grade.test.IsPublished = false;
+          component.hasFinalGrade = true;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+
+        it("is disabled for published test with final grade", async () => {
+          grade.test.IsPublished = true;
+          component.hasFinalGrade = true;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+      });
+
+      describe("without points defined", () => {
+        beforeEach(() => {
+          grade.result.Points = 1;
+        });
+
+        it("is disabled for non-published test without final grade", async () => {
+          grade.test.IsPublished = false;
+          component.hasFinalGrade = false;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+
+        it("is disabled for published test without final grade", async () => {
+          grade.test.IsPublished = true;
+          component.hasFinalGrade = false;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+
+        it("is disabled for non-published test with final grade", async () => {
+          grade.test.IsPublished = false;
+          component.hasFinalGrade = true;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+
+        it("is disabled for published test with final grade", async () => {
+          grade.test.IsPublished = true;
+          component.hasFinalGrade = true;
+          fixture.detectChanges();
+
+          const select = await queryGradeSelect();
+          expect(select?.disabled).toBe(true);
+        });
+      });
+    });
   });
 
-  describe("enable and disable grading scale options", () => {
-    let grade: GradeKind;
+  async function queryGradeSelect(): Promise<Option<HTMLSelectElement>> {
+    return query("select");
+  }
 
-    beforeEach(() => {
-      grade = {
-        kind: "grade",
-        result,
-        test,
-      };
-    });
+  async function queryPointsInput(): Promise<Option<HTMLInputElement>> {
+    return query("input");
+  }
 
-    it("should disable gradingScale when result has points", () => {
-      // given
-      grade.test.IsPointGrading = true;
-      grade.result.Points = 11;
-
-      // when
-      component.grade = grade;
-      fixture.detectChanges();
-
-      component.gradingScaleDisabled$.subscribe((result) =>
-        expect(result).toBe(true),
-      );
-    });
-
-    it("should enable gradingScale when result does not have points", () => {
-      // given
-      grade.test.IsPointGrading = true;
-      grade.result.Points = null;
-      component.grade = grade;
-
-      // when
-      fixture.detectChanges();
-
-      component.gradingScaleDisabled$.subscribe((result) =>
-        expect(result).toBe(false),
-      );
-    });
-
-    it("should enable gradingScale when input is changed to empty", () => {
-      // given
-      grade.test.IsPointGrading = true;
-      grade.result.Points = 11;
-
-      component.grade = grade;
-      fixture.detectChanges();
-
-      // when
-      component.onPointsChange("");
-
-      // then
-      component.gradingScaleDisabled$.subscribe((result) =>
-        expect(result).toBe(false),
-      );
-    });
-
-    it("should enable gradingScale when test is not point grading", () => {
-      // given
-      grade.test.IsPointGrading = false;
-      grade.result.Points = null;
-
-      component.grade = grade;
-
-      // when
-      fixture.detectChanges();
-
-      // then
-      component.gradingScaleDisabled$.subscribe((result) =>
-        expect(result).toBe(false),
-      );
-    });
-  });
+  async function query<T>(selector: string): Promise<Option<T>> {
+    await fixture.whenStable();
+    return debugElement.query(By.css(selector))?.nativeElement ?? null;
+  }
 });
-
-function expectPointsInputValue(debugElement: DebugElement, expected: string) {
-  const input = debugElement.query(byTestId("point-input")).nativeElement;
-  expect(input.value).toBe(expected);
-}

--- a/src/app/events/components/grade/grade.component.ts
+++ b/src/app/events/components/grade/grade.component.ts
@@ -36,6 +36,7 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
   @Input() student: Student;
   @Input() tabIndex: number;
   @Input() gradeOptions: DropDownItem[];
+  @Input() hasFinalGrade = false;
 
   maxPoints: number = 0;
 
@@ -51,7 +52,7 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
   constructor(private state: TestStateService) {}
 
   ngOnInit(): void {
-    this.gradingScaleDisabledSubject$.next(this.disableGradingScale());
+    this.gradingScaleDisabledSubject$.next(this.isGradingScaleDisabled());
 
     this.maxPoints = toMaxPoints(this.grade);
     this.initSave(
@@ -76,7 +77,7 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnChanges() {
-    this.gradingScaleDisabledSubject$.next(this.disableGradingScale());
+    this.gradingScaleDisabledSubject$.next(this.isGradingScaleDisabled());
   }
 
   ngOnDestroy() {
@@ -118,9 +119,13 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
       );
   }
 
-  private disableGradingScale() {
-    if (this.grade.test.IsPublished) return true;
-    if (this.grade.kind === "no-result") return false;
-    return this.grade.result.Points != null && this.grade.test.IsPointGrading;
+  private isGradingScaleDisabled() {
+    return (
+      this.grade.test.IsPublished ||
+      this.hasFinalGrade ||
+      (this.grade.test.IsPointGrading &&
+        this.grade.kind === "grade" &&
+        this.grade.result.Points != null)
+    );
   }
 }

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.html
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.html
@@ -37,7 +37,7 @@
               <div>{{ studentGrade.student.FullName }}</div>
               <div class="student-average-inline">
                 {{ "tests.mean" | translate }}:
-                {{ studentGrade.finalGrade?.average | decimalOrDash: "1-3" }}
+                {{ studentGrade.finalGrade.average | decimalOrDash: "1-3" }}
               </div>
             </a>
           </td>
@@ -45,29 +45,24 @@
             class="sticky student-grade"
             [ngClass]="{ selected: selectedTest === undefined }"
           >
-            @if (
-              studentGrade.finalGrade && !studentGrade.finalGrade.freeHandGrade
-            ) {
+            @if (studentGrade.finalGrade.finalGradeValue) {
+              <div>
+                {{ studentGrade.finalGrade.finalGradeValue }}
+              </div>
+            } @else {
               <bkd-grade-select
                 [options]="state.gradingOptionsForCourse$() | async"
-                [valueId]="studentGrade.finalGrade.finalGradeId"
-                [gradeId]="studentGrade.finalGrade.id"
+                [valueId]="studentGrade.finalGrade.gradeId ?? null"
+                [gradeId]="studentGrade.finalGrade.gradingId ?? null"
                 [disabled]="
                   (isEditFinalGradesAllowed(studentGrade) | async) === false
                 "
                 (gradeIdSelected)="state.overwriteFinalGrade($event)"
               ></bkd-grade-select>
             }
-            @if (
-              studentGrade.finalGrade && studentGrade.finalGrade.freeHandGrade
-            ) {
-              <div>
-                {{ studentGrade.finalGrade.freeHandGrade }}
-              </div>
-            }
           </td>
           <td class="border-end sticky student-average">
-            {{ studentGrade.finalGrade?.average | decimalOrDash: "1-3" }}
+            {{ studentGrade.finalGrade.average | decimalOrDash: "1-3" }}
           </td>
           @for (
             gradeEntry of getGrades(studentGrade);
@@ -89,6 +84,7 @@
                   state.gradingOptionsForTest$(grade.test) | async
                 "
                 [student]="studentGrade.student"
+                [hasFinalGrade]="!!studentGrade.finalGrade.finalGradeValue"
                 [tabIndex]="(1 + gradeIndex) * 1000 + studentGradeIndex"
               ></bkd-grade>
             </td>

--- a/src/app/events/components/test-edit-grades/test-edit-grades.component.spec.ts
+++ b/src/app/events/components/test-edit-grades/test-edit-grades.component.spec.ts
@@ -1,7 +1,14 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { BehaviorSubject, of } from "rxjs";
+import { Course } from "src/app/shared/models/course.model";
+import { StudentGrade } from "src/app/shared/models/student-grades";
 import { Test } from "src/app/shared/models/test.model";
-import { buildCourse, buildResult, buildTest } from "src/spec-builders";
+import {
+  buildCourse,
+  buildResult,
+  buildStudent,
+  buildTest,
+} from "src/spec-builders";
 import { buildTestModuleMetadata } from "src/spec-helpers";
 import {
   INITIAL_TESTS_FILTER,
@@ -14,7 +21,10 @@ describe("TestEditGradesComponent", () => {
   let fixture: ComponentFixture<TestEditGradesComponent>;
   let element: HTMLElement;
 
-  let test: Test;
+  let course: Course;
+  let gradeTest: Test;
+  let pointsTest: Test;
+  let studentGrades: StudentGrade[];
   let testStateServiceMock: jasmine.SpyObj<TestStateService>;
 
   let tests$: BehaviorSubject<Test[]>;
@@ -22,16 +32,44 @@ describe("TestEditGradesComponent", () => {
   let canSetFinalGrade$: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
-    test = buildTest(1234, 12, [buildResult(12, 1)]);
+    const gradeResult = buildResult(12, 1);
+    gradeResult.TestId = 12;
+    gradeResult.StudentId = 100;
+    gradeResult.GradeId = 1005;
+    gradeResult.GradeValue = 5.0;
+    gradeResult.GradeDesignation = "5.0";
+    gradeTest = buildTest(1234, 12, [gradeResult]);
+
+    const pointsResult = buildResult(13, 1);
+    pointsResult.TestId = 13;
+    pointsResult.StudentId = 100;
+    pointsResult.GradeId = 1005;
+    pointsResult.GradeValue = 5.0;
+    pointsResult.GradeDesignation = "5.0";
+    pointsResult.Points = 25;
+    pointsTest = buildTest(1234, 13, [pointsResult]);
+    pointsTest.IsPointGrading = true;
+    pointsTest.MaxPoints = 30;
+
     testStateServiceMock = jasmine.createSpyObj("TestStateService", [
       "canSetFinalGrade$",
       "setSorting",
       "getSortingChar$",
-      "course$",
+      "gradingOptionsForCourse$",
+      "gradingOptionsForTest$",
     ]);
 
-    testStateServiceMock.course$ = of(buildCourse(1234));
-    tests$ = new BehaviorSubject([test]);
+    course = buildCourse(1234);
+    course.EvaluationStatusRef = {
+      Id: 1,
+      HRef: null,
+      HasEvaluationStarted: true,
+      EvaluationUntil: null,
+      HasReviewOfEvaluationStarted: false,
+      HasTestGrading: true,
+    };
+    testStateServiceMock.course$ = of(course);
+    tests$ = new BehaviorSubject([gradeTest, pointsTest]);
     testStateServiceMock.tests$ = tests$;
     testStateServiceMock.filteredTests$ = tests$;
     hasTests$ = new BehaviorSubject(true);
@@ -40,6 +78,47 @@ describe("TestEditGradesComponent", () => {
     testStateServiceMock.canSetFinalGrade$ = canSetFinalGrade$;
     testStateServiceMock.filter$ = of(INITIAL_TESTS_FILTER);
     testStateServiceMock.expandedHeader$ = of(false);
+
+    const gradingOptions = [
+      { Key: 1001, Value: "1.0" },
+      { Key: 1002, Value: "2.0" },
+      { Key: 1003, Value: "3.0" },
+      { Key: 1004, Value: "4.0" },
+      { Key: 1005, Value: "5.0" },
+      { Key: 1006, Value: "6.0" },
+    ];
+    testStateServiceMock.gradingOptionsForCourse$.and.returnValue(
+      of(gradingOptions),
+    );
+    testStateServiceMock.gradingOptionsForTest$.and.returnValue(
+      of(gradingOptions),
+    );
+
+    const student = buildStudent(100);
+    studentGrades = [
+      {
+        student,
+        finalGrade: {
+          gradingId: 10000,
+          average: 5.33,
+          gradeId: 1005,
+          canGrade: true,
+        },
+        grades: [
+          {
+            kind: "grade",
+            result: gradeResult,
+            test: gradeTest,
+          },
+          {
+            kind: "grade",
+            result: pointsResult,
+            test: pointsTest,
+          },
+        ],
+      },
+    ];
+    testStateServiceMock.studentGrades$ = of(studentGrades);
 
     await TestBed.configureTestingModule(
       buildTestModuleMetadata({
@@ -60,8 +139,126 @@ describe("TestEditGradesComponent", () => {
     element = fixture.debugElement.nativeElement;
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("gradings & final grades", () => {
+    describe("with grading that has grade but without final grade", () => {
+      beforeEach(async () => {
+        fixture.detectChanges();
+        await fixture.whenStable();
+      });
+
+      it("renders editable final grade select with grade value from grading", () => {
+        const finalGradeSelect = queryFinalGradeSelect();
+        expect(getSelectValue(finalGradeSelect)).toBe("5.0");
+        expect(finalGradeSelect.disabled).toBe(false);
+      });
+
+      it("renders average from grading", () => {
+        const average = queryStudentAverage();
+        expect(average?.textContent?.trim()).toBe("5.33");
+      });
+
+      it("renders editable grade grading test result", () => {
+        const gradeTestSelect = queryGradeTestSelect();
+        expect(gradeTestSelect).not.toBeNull();
+        expect(getSelectValue(gradeTestSelect!)).toBe("5.0");
+        expect(gradeTestSelect?.disabled).toBe(false);
+      });
+
+      it("renders editable points grading test result", () => {
+        const pointsTestInput = queryPointsTestInput();
+        expect(pointsTestInput).not.toBeNull();
+        expect(pointsTestInput?.disabled).toBe(false);
+
+        const pointsTestSelect = queryPointsTestSelect();
+        expect(pointsTestSelect).not.toBeNull();
+        expect(getSelectValue(pointsTestSelect!)).toBe("5.0");
+        expect(pointsTestSelect?.disabled).toBe(true);
+      });
+    });
+
+    describe("with grading that has no grade but without final grade", () => {
+      beforeEach(async () => {
+        studentGrades[0].finalGrade.gradeId = undefined;
+        testStateServiceMock.studentGrades$ = of(studentGrades);
+        fixture.detectChanges();
+        await fixture.whenStable();
+      });
+
+      it("renders editable final grade select without value selected", () => {
+        const finalGradeSelect = queryFinalGradeSelect();
+        expect(getSelectValue(finalGradeSelect)).toBe("");
+        expect(finalGradeSelect.disabled).toBe(false);
+      });
+
+      it("renders average from grading", () => {
+        const average = queryStudentAverage();
+        expect(average?.textContent?.trim()).toBe("5.33");
+      });
+
+      it("renders editable grade grading test result", () => {
+        const gradeTestSelect = queryGradeTestSelect();
+        expect(gradeTestSelect).not.toBeNull();
+        expect(getSelectValue(gradeTestSelect!)).toBe("5.0");
+        expect(gradeTestSelect?.disabled).toBe(false);
+      });
+
+      it("renders editable points grading test result", () => {
+        const pointsTestInput = queryPointsTestInput();
+        expect(pointsTestInput).not.toBeNull();
+        expect(pointsTestInput?.disabled).toBe(false);
+
+        const pointsTestSelect = queryPointsTestSelect();
+        expect(pointsTestSelect).not.toBeNull();
+        expect(getSelectValue(pointsTestSelect!)).toBe("5.0");
+        expect(pointsTestSelect?.disabled).toBe(true);
+      });
+    });
+
+    describe("with final grading but without grading", () => {
+      beforeEach(async () => {
+        studentGrades[0].finalGrade.gradingId = undefined;
+        studentGrades[0].finalGrade.gradeId = undefined;
+        studentGrades[0].finalGrade.finalGradeValue = "5.4";
+        studentGrades[0].finalGrade.canGrade = false;
+
+        testStateServiceMock.studentGrades$ = of(studentGrades);
+        fixture.detectChanges();
+        await fixture.whenStable();
+      });
+
+      it("renders non-editable final grade static value (no select) with grade value from final grade", () => {
+        const finalGradeSelect = queryFinalGradeSelect();
+        expect(finalGradeSelect).toBeNull();
+
+        const finalGradeCell = element.querySelector(
+          "td.student-grade:not(:last-child)",
+        );
+        expect(finalGradeCell?.textContent?.trim()).toBe("5.4");
+      });
+
+      it("renders average from final grade", () => {
+        const average = queryStudentAverage();
+        expect(average?.textContent?.trim()).toBe("5.33");
+      });
+
+      it("renders non-editable grade grading test result", () => {
+        const gradeTestSelect = queryGradeTestSelect();
+        expect(gradeTestSelect).not.toBeNull();
+        expect(getSelectValue(gradeTestSelect!)).toBe("5.0");
+        expect(gradeTestSelect?.disabled).toBe(true);
+      });
+
+      it("renders non-editable points grading test result", () => {
+        const pointsTestInput = queryPointsTestInput();
+        expect(pointsTestInput).not.toBeNull();
+        expect(pointsTestInput?.disabled).toBe(true);
+
+        const pointsTestSelect = queryPointsTestSelect();
+        expect(pointsTestSelect).not.toBeNull();
+        expect(getSelectValue(pointsTestSelect!)).toBe("5.0");
+        expect(pointsTestSelect?.disabled).toBe(true);
+      });
+    });
   });
 
   describe("set average as final grade button", () => {
@@ -98,7 +295,7 @@ describe("TestEditGradesComponent", () => {
 
       it("is not visible on mobile if test is selected and tests are available", () => {
         fixture.detectChanges();
-        component.selectedTest = test;
+        component.selectedTest = gradeTest;
         fixture.detectChanges();
 
         const button = getAverageFinalGradeButton();
@@ -119,6 +316,43 @@ describe("TestEditGradesComponent", () => {
       });
     });
   });
+
+  function queryFinalGradeSelect(): HTMLSelectElement {
+    return element.querySelector(
+      "td.student-grade:not(:last-child) [data-testid='grade-select'] select",
+    ) as HTMLSelectElement;
+  }
+
+  function getSelectValue(select: HTMLSelectElement): Option<string> {
+    return select.selectedOptions[0].text;
+  }
+
+  function queryStudentAverage(): Option<HTMLElement> {
+    return element.querySelector("tr:not(:last-child) td.student-average");
+  }
+
+  function queryGradeTestSelect(): Option<HTMLSelectElement> {
+    return queryGradeTestCell()?.querySelector("select") ?? null;
+  }
+
+  function queryGradeTestCell(): Option<HTMLElement> {
+    return document.querySelectorAll<HTMLElement>(
+      "tr:not(:last-child) td.test-grade",
+    )[0];
+  }
+
+  function queryPointsTestInput(): Option<HTMLInputElement> {
+    return queryPointsTestCell()?.querySelector("input") ?? null;
+  }
+  function queryPointsTestSelect(): Option<HTMLSelectElement> {
+    return queryPointsTestCell()?.querySelector("select") ?? null;
+  }
+
+  function queryPointsTestCell(): Option<HTMLElement> {
+    return document.querySelectorAll<HTMLElement>(
+      "tr:not(:last-child) td.test-grade",
+    )[1];
+  }
 
   function getAverageFinalGradeButton() {
     return element.querySelector('[data-testid="apply-average-button"]');

--- a/src/spec-builders.ts
+++ b/src/spec-builders.ts
@@ -800,10 +800,10 @@ export function buildGradeKind(
 
 function buildFinalGrade(): FinalGrade {
   return {
-    id: 12,
+    gradingId: 12,
     average: 4,
-    finalGradeId: 20,
-    freeHandGrade: 5.5,
+    gradeId: 20,
+    finalGradeValue: "5.5",
     canGrade: true,
   };
 }


### PR DESCRIPTION
Siehe #769

Im Folgenden die drei Fälle welche bei GymBivo vorhanden sind. Vom Verhalten her ändert sich lediglich die beiden fette markierten Punkte bei Fall 2.

### Fall 1 (Englisch-S3, 27a, PMVDA2023a, PMVDA2023f)

- Keine Final Grades vorhanden
- Auf dem Grading gibt es keine GradeId und CanGrade ist false

→ Es ist keine Note gesetzt, das Gesamtnoten-Select ist disabled und die Tests-Felder sind bearbeitbar (enabled)

### Fall 2 (Englisch-S3, 26b)

- Julianne & Anna haben Final Grades (aber kein Grading)
- Amélie hat ein Grading (aber keine Final Grade) wobei es keine GradeId gibt und CanGrade false ist

→ Amélie wird gleich angezeigt wie die Einträge von Fall 1 (keine Note gesetzt, Gesamtnoten-Select disabled und Tests-Felder bearbeitbar)
→ **Bei Julianne & Anna wird die Final Grade angezeigt bei der Gesamtnote (statisch, kein Select) und die Tests-Felder sind nicht bearbeitbar (disabled); vorher waren die Test-Felder immer noch bearbeitbar**
→ **Die Bei Julianne & Anna wird der Mittelwert von der Final Grade angezeigt; vorher wurde kein Mittelwert angezeigt**

### Fall 3 (Deutsch-S1, 27a)

- Keine Final Grades vorhanden
- Auf dem Grading kann eine GradeId gesetzt sein oder nicht und CanGrade ist true

→ Das Gesamtnoten-Select ist bearbeitbar und es ist eine Note gesetzt wenn GradeId vorhanden, sonst nicht. Die Tests-Felder sind bei allen Einträgen bearbeitbar.

### Zusammenfassung

- Wenn es eine Final Grade gibt sind weder Gesamtnote, noch Tests-Felder bearbeitbar (ganze Zeile disabled)
- Wenn es ein Grading gibt sind die Tests-Felder immer bearbeitbar
- Wenn es ein Grading ist das Gesamtnoten-Select nur bearbeitbar wenn CanGrade true ist, sonst disabled
- Einträge mit Final Grade und Grading gibt es nicht
- Einträge ohne Final Grade und ohne Grading gibt es nicht