### PR TITLE
Fix wrong datepicker date conversion #765

### DIFF
--- a/src/app/presence-control/components/presence-control-header/presence-control-header.component.html
+++ b/src/app/presence-control/components/presence-control-header/presence-control-header.component.html
@@ -8,7 +8,7 @@
     <input
       class="lesson-date-input"
       [ngModel]="selectDate"
-      (ngModelChange)="selectDateChange.emit($event)"
+      (ngModelChange)="onDateChange($event)"
       positionTarget=".lesson-date-input"
       ngbDatepicker
       placement="bottom-start"

--- a/src/app/presence-control/components/presence-control-header/presence-control-header.component.ts
+++ b/src/app/presence-control/components/presence-control-header/presence-control-header.component.ts
@@ -147,4 +147,11 @@ export class PresenceControlHeaderComponent {
       };
     };
   }
+
+  onDateChange(date: unknown) {
+    if (date instanceof Date) {
+      // Only emit the new date value if it is a valid date
+      this.selectDateChange.emit(date);
+    }
+  }
 }

--- a/src/app/shared/services/date-parser-formatter.ts
+++ b/src/app/shared/services/date-parser-formatter.ts
@@ -15,8 +15,8 @@ export class DateParserFormatter extends NgbDateParserFormatter {
     if (date) {
       return {
         year: date.getFullYear(),
-        month: date.getMonth(),
-        day: date.getDay(),
+        month: date.getMonth() + 1,
+        day: date.getDate(),
       };
     }
     return null as unknown as NgbDateStruct;


### PR DESCRIPTION
#765

- [x] Das eingegeben Datum wird falsch korrigiert, mit Monat - 1 und Wochentag statt Tag im Monat → gefixt
- [ ] Der Datepicker lädt neu, sobald ein valides Datum drinsteht. Dies funkt beim Bearbeiten dazwischen.