### PR TITLE
Transform value to corresponding dropdown item's key #758

### DIFF
--- a/src/app/import/services/subscription-details/import-upload-subscription-details.service.spec.ts
+++ b/src/app/import/services/subscription-details/import-upload-subscription-details.service.spec.ts
@@ -117,6 +117,25 @@ describe("ImportUploadSubscriptionDetailsService", () => {
         total: 3,
       });
     });
+
+    it("sends `Key` of corresponding dropdown item as value", async () => {
+      const entry = buildEntry(
+        { eventId: 11, subscriptionDetailId: 1001, value: "Apple" },
+        { validationStatus: "valid", importStatus: null },
+      );
+      entry.data.subscriptionDetail!.DropdownItems = [
+        { Key: 10, Value: "Apple", IsActive: true },
+        { Key: 11, Value: "Pear", IsActive: true },
+      ];
+
+      await service.upload([entry]);
+
+      expect(subscriptionDetailsServiceMock.update).toHaveBeenCalledTimes(1);
+
+      const value =
+        subscriptionDetailsServiceMock.update.calls.mostRecent().args[1];
+      expect(value).toBe(10);
+    });
   });
 
   function buildEntry(


### PR DESCRIPTION
Im Excel soll der DropdownItem `Value` stehen können, dieser muss aber beim Upload auf den DropdownItem `Key` umgesetzt werden.

In diesem PR wenden wir diese Übersetzung auf den `Key` beim Upload und bei der Überprüfung ob der Wert geändert hat an.