### PR TITLE
Don't load other teachers' absences if not today #803

### DIFF
--- a/src/app/presence-control/services/presence-control-state.service.spec.ts
+++ b/src/app/presence-control/services/presence-control-state.service.spec.ts
@@ -232,7 +232,6 @@ describe("PresenceControlStateService", () => {
     );
     expectLessonsRequest(lessonsFromPresences([werkenFrisch]), "2000-01-10");
     expectLessonPresencesRequest([werkenFrisch], [99]);
-    expectLoadOtherTeachersAbsencesRequest([], person.Id, [123]);
 
     expect(selectedLessonCb).toHaveBeenCalledWith(
       fromLesson(

--- a/src/app/presence-control/services/presence-control-state.service.ts
+++ b/src/app/presence-control/services/presence-control-state.service.ts
@@ -1,7 +1,7 @@
 import { Location } from "@angular/common";
 import { Injectable, OnDestroy, inject } from "@angular/core";
 import { Params } from "@angular/router";
-import { format, startOfDay } from "date-fns";
+import { format, isToday, startOfDay } from "date-fns";
 import { isEqual, uniq } from "lodash-es";
 import {
   BehaviorSubject,
@@ -150,10 +150,12 @@ export class PresenceControlStateService
     shareReplay(1),
   );
 
-  otherTeachersAbsences$ = this.studentIds$.pipe(
-    distinctUntilChanged(isEqual),
-    switchMap((studentIds) =>
-      studentIds.length > 0
+  otherTeachersAbsences$ = combineLatest([
+    this.studentIds$.pipe(distinctUntilChanged(isEqual)),
+    this.selectedDate$,
+  ]).pipe(
+    switchMap(([studentIds, date]) =>
+      studentIds.length > 0 && isToday(date)
         ? this.lessonTeacherService.loadOtherTeachersLessonAbsences(
             this.getMyself(),
             studentIds,


### PR DESCRIPTION
#803

Dieser PR implementiert den zweiten Punkt im Ticket:

> Request soll nur ausgeführt werden wenn das ausgewählte Datum Heute ist

Leider kann man es nur testen mit einer Lehrperson, welche am aktuellen Tag Lektionen hat. In diesem Fall sollte ein `/LessonTeachers/` Request gemacht werden, an anderen Tagen nicht.