### PR TITLE
Fix designation for module events without classes #827

### DIFF
--- a/src/app/events/services/evaluation-state.service.spec.ts
+++ b/src/app/events/services/evaluation-state.service.spec.ts
@@ -255,6 +255,22 @@ describe("EvaluationStateService", () => {
         expect(result).toBeNull();
       });
     }));
+
+    it("returns module event without class (special case of course)", fakeAsync(async () => {
+      course.Classes = null;
+      coursesServiceMock.getCourseWithStudentCount.and.returnValue(of(course));
+      params.next({ id: "1000" });
+
+      await expectSignalValue(service.event, (result) => {
+        expect(result).toEqual({
+          id: 1000,
+          designation: "Mathematik",
+          type: "course",
+          studentCount: 24,
+          gradingScaleId: 10000,
+        });
+      });
+    }));
   });
 
   describe("columns", () => {

--- a/src/app/events/services/evaluation-state.service.ts
+++ b/src/app/events/services/evaluation-state.service.ts
@@ -226,9 +226,14 @@ export class EvaluationStateService {
   private buildEvaluationEventFromCourse(
     course: CourseWithStudentCount,
   ): EvaluationEvent {
+    const classes = course.Classes?.map((c) => c.Number) ?? [];
+    const designation =
+      classes.length > 0
+        ? `${course.Designation}, ${classes.join(", ")}`
+        : course.Designation;
     return {
       id: course.Id,
-      designation: `${course.Designation}, ${course.Classes?.map((c) => c.Number).join(", ")}`,
+      designation,
       type: "course",
       studentCount: course.AttendanceRef.StudentCount ?? 0,
       gradingScaleId: course.GradingScaleId,


### PR DESCRIPTION
#827

Beispiel: http://localhost:4200/#/events/10058/evaluation