### PR TITLE
Subscription detail fields #812

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -84,6 +84,14 @@ export const routes: Routes = [
       ),
   },
   {
+    path: "kitchensink",
+    canActivate: [devModeGuard()],
+    loadChildren: () =>
+      import("./kitchensink/kitchensink.routes").then(
+        (m) => m.KITCHENSINK_ROUTES,
+      ),
+  },
+  {
     path: "api",
     canActivate: [authGuard(), devModeGuard()],
     loadChildren: () => import("./api/api.routes").then((m) => m.API_ROUTES),

--- a/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.html
+++ b/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.html
@@ -49,8 +49,13 @@
               class="subscription-detail"
               [class.selected]="isColumnSelected(detail)"
             >
-              <!-- TODO: render subscription detail -->
-              {{ detail?.Value }}
+              @if (detail) {
+                <bkd-subscription-detail-field
+                  [detail]="detail"
+                  [hideLabel]="true"
+                  [layout]="'horizontal'"
+                ></bkd-subscription-detail-field>
+              }
             </td>
           }
 

--- a/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.spec.ts
+++ b/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.spec.ts
@@ -42,14 +42,26 @@ describe("EvaluationTableComponent", () => {
     detail1.Tooltip = "Art der Anforderungen";
     detail1.IdPerson = gradingItem1.IdPerson;
     detail1.Sort = "10";
-    detail1.Value = "GE";
+    detail1.VssStyle = "LB";
+    detail1.DropdownItems = [
+      { Key: 1, Value: "EA", IsActive: true },
+      { Key: 2, Value: "GE", IsActive: true },
+    ];
+    detail1.ShowAsRadioButtons = true;
+    detail1.Value = 2;
 
     detail2 = buildSubscriptionDetail(3902);
     detail2.VssDesignation = "Anforderungen";
     detail2.Tooltip = "Art der Anforderungen";
     detail2.IdPerson = gradingItem2.IdPerson;
     detail2.Sort = "11";
-    detail2.Value = "EA";
+    detail2.VssStyle = "LB";
+    detail2.DropdownItems = [
+      { Key: 1, Value: "EA", IsActive: true },
+      { Key: 2, Value: "GE", IsActive: true },
+    ];
+    detail2.ShowAsRadioButtons = true;
+    detail2.Value = 1;
 
     detail3 = buildSubscriptionDetail(3936);
     detail3.VssDesignation = "Pünktlichkeit";
@@ -136,7 +148,7 @@ describe("EvaluationTableComponent", () => {
     });
 
     it("renders the subscription detail columns", () => {
-      expect(getColumnValues(2)).toEqual(["EA", "GE"]);
+      expect(getColumnValues(2)).toEqual(["EA  GE", "EA  GE"]);
       expect(getColumnValues(3)).toEqual(["", ""]); // No values exist for this column
     });
 
@@ -156,7 +168,7 @@ describe("EvaluationTableComponent", () => {
     });
 
     it("renders the subscription detail columns", () => {
-      expect(getColumnValues(1)).toEqual(["EA", "GE"]);
+      expect(getColumnValues(1)).toEqual(["EA  GE", "EA  GE"]);
       expect(getColumnValues(2)).toEqual(["", ""]); // No values exist for this column
     });
 

--- a/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.ts
+++ b/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.ts
@@ -10,6 +10,7 @@ import { TranslatePipe } from "@ngx-translate/core";
 import { SortCriteria } from "src/app/shared/components/sortable-header/sortable-header.component";
 import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
 import { average } from "src/app/shared/utils/math";
+import { SubscriptionDetailFieldComponent } from "../../../../shared/components/subscription-detail-field/subscription-detail-field.component";
 import { DecimalOrDashPipe } from "../../../../shared/pipes/decimal-or-dash.pipe";
 import {
   EvaluationColumn,
@@ -33,6 +34,7 @@ import { EvaluationTableHeaderComponent } from "../evaluation-table-header/evalu
     EvaluationTableHeaderComponent,
     TableHeaderStickyDirective,
     DecimalOrDashPipe,
+    SubscriptionDetailFieldComponent,
   ],
   templateUrl: "./evaluation-table.component.html",
   styleUrl: "./evaluation-table.component.scss",

--- a/src/app/home/components/home.component.spec.ts
+++ b/src/app/home/components/home.component.spec.ts
@@ -41,6 +41,7 @@ describe("HomeComponent", () => {
       "/my-profile",
       "/my-grades",
       "/my-settings",
+      "/kitchensink",
       "/api",
     ]);
   });

--- a/src/app/home/components/home.component.ts
+++ b/src/app/home/components/home.component.ts
@@ -40,6 +40,7 @@ export class HomeComponent {
     { path: "my-profile" },
     { path: "my-grades" },
     { path: "my-settings" },
+    { path: "kitchensink" },
     { path: "api" },
   ];
 }

--- a/src/app/kitchensink/components/kitchensink/kitchensink.component.html
+++ b/src/app/kitchensink/components/kitchensink/kitchensink.component.html
@@ -1,0 +1,77 @@
+<h1>Kitchensink</h1>
+
+<h2>Subscription Detail Fields: With Labels</h2>
+<div class="subscription-details with-border">
+  <div class="subscription-details-row">
+    <div>Field</div>
+    <div>Value</div>
+    <div>Properties</div>
+  </div>
+  @for (props of subscriptionDetails; track props.Id) {
+    @let detail = subscriptionDetailsSignals[props.Id || ""];
+    <div class="subscription-details-row">
+      <div>
+        <bkd-subscription-detail-field
+          [detail]="detail()"
+          (detailChange)="detail.set($event)"
+        ></bkd-subscription-detail-field>
+      </div>
+      <pre>{{ detail().Value | json }}</pre>
+      <pre>{{ props | json }}</pre>
+    </div>
+  }
+</div>
+
+<h2>Subscription Detail Fields: Without labels</h2>
+<div class="subscription-details">
+  @for (detail of subscriptionDetails; track detail.Id) {
+    <div class="subscription-details-row">
+      <div>
+        <bkd-subscription-detail-field
+          [detail]="build(detail)"
+          [hideLabel]="true"
+        ></bkd-subscription-detail-field>
+      </div>
+    </div>
+  }
+</div>
+
+<h2>Subscription Detail Fields: Readonly</h2>
+<div class="subscription-details">
+  @for (detail of subscriptionDetailsReadonly; track detail.Id) {
+    <div class="subscription-details-row">
+      <div>
+        <bkd-subscription-detail-field
+          [detail]="build(detail)"
+        ></bkd-subscription-detail-field>
+      </div>
+    </div>
+  }
+</div>
+
+<h2>Subscription Detail Fields: Required</h2>
+<div class="subscription-details">
+  @for (detail of subscriptionDetailsRequired; track detail.Id) {
+    <div class="subscription-details-row">
+      <div>
+        <bkd-subscription-detail-field
+          [detail]="build(detail)"
+        ></bkd-subscription-detail-field>
+      </div>
+    </div>
+  }
+</div>
+
+<h2>Subscription Detail Fields: Horizontal Layout</h2>
+<div class="subscription-details">
+  @for (detail of subscriptionDetails; track detail.Id) {
+    <div class="subscription-details-row">
+      <div>
+        <bkd-subscription-detail-field
+          [detail]="build(detail)"
+          [layout]="'horizontal'"
+        ></bkd-subscription-detail-field>
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/kitchensink/components/kitchensink/kitchensink.component.scss
+++ b/src/app/kitchensink/components/kitchensink/kitchensink.component.scss
@@ -1,0 +1,46 @@
+@import "../../../../bootstrap-variables";
+
+:host {
+  display: block;
+  margin: $spacer;
+}
+
+.subscription-details {
+  display: flex;
+  flex-direction: column;
+  column-gap: $spacer;
+  margin-bottom: 3 * $spacer;
+}
+
+.subscription-details-row {
+  display: flex;
+  align-items: start;
+  gap: $spacer;
+  margin-bottom: 1.25 * $spacer;
+}
+
+.subscription-details-row:first-child > * {
+  font-weight: bold;
+}
+
+.with-border {
+  .subscription-details-row {
+    margin-bottom: 0;
+    padding-top: $spacer;
+    padding-bottom: $spacer;
+  }
+
+  .subscription-details-row + .subscription-details-row {
+    border-top: 1px solid $gray-200;
+  }
+}
+
+.subscription-details-row > * {
+  flex: 1;
+}
+
+.subscription-details-row pre {
+  background-color: $gray-200;
+  padding: $spacer;
+  margin: 0;
+}

--- a/src/app/kitchensink/components/kitchensink/kitchensink.component.spec.ts
+++ b/src/app/kitchensink/components/kitchensink/kitchensink.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { KitchensinkComponent } from "./kitchensink.component";
+
+describe("KitchensinkComponent", () => {
+  let component: KitchensinkComponent;
+  let fixture: ComponentFixture<KitchensinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [KitchensinkComponent],
+      }),
+    ).compileComponents();
+
+    fixture = TestBed.createComponent(KitchensinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/kitchensink/components/kitchensink/kitchensink.component.ts
+++ b/src/app/kitchensink/components/kitchensink/kitchensink.component.ts
@@ -1,0 +1,165 @@
+import { JsonPipe } from "@angular/common";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  WritableSignal,
+  signal,
+} from "@angular/core";
+import {
+  SubscriptionDetail,
+  SubscriptionDetailType,
+} from "src/app/shared/models/subscription.model";
+import { SubscriptionDetailFieldComponent } from "../../../shared/components/subscription-detail-field/subscription-detail-field.component";
+
+@Component({
+  selector: "bkd-kitchensink",
+  imports: [JsonPipe, SubscriptionDetailFieldComponent],
+  templateUrl: "./kitchensink.component.html",
+  styleUrl: "./kitchensink.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KitchensinkComponent {
+  subscriptionDetails: ReadonlyArray<Partial<SubscriptionDetail>> = [
+    {
+      VssDesignation: "Heading",
+      VssStyle: "HE",
+    },
+    {
+      VssDesignation: "Description",
+      VssStyle: "BE",
+      Value:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    },
+    {
+      VssDesignation: "Text field",
+      VssTypeId: SubscriptionDetailType.ShortText,
+      VssStyle: "TX",
+      Value: "Lorem ipsum",
+    },
+    {
+      VssDesignation: "Integer field",
+      VssTypeId: SubscriptionDetailType.Int,
+      VssStyle: "TX",
+      Value: 42,
+    },
+    {
+      VssDesignation: "Currency field",
+      VssStyle: "TX",
+      VssTypeId: SubscriptionDetailType.Currency,
+      Value: "12.30",
+    },
+    {
+      VssDesignation: "Textarea",
+      VssTypeId: SubscriptionDetailType.Text,
+      VssStyle: "TX",
+      Value: "Lorem ipsum\ndolor sit amet",
+    },
+    {
+      VssDesignation: "Date field",
+      VssStyle: "TX",
+      VssTypeId: SubscriptionDetailType.Date,
+      Value: "23.01.2000",
+    },
+    {
+      VssDesignation: "Yes/no checkbox",
+      VssStyle: "TX",
+      VssTypeId: SubscriptionDetailType.YesNo,
+      ShowAsRadioButtons: false,
+      Value: "Nein",
+    },
+    {
+      VssDesignation: "Yes/no radios",
+      VssStyle: "TX",
+      VssTypeId: SubscriptionDetailType.YesNo,
+      ShowAsRadioButtons: true,
+      Value: "Nein",
+    },
+    {
+      VssDesignation: "Yes checkbox",
+      VssStyle: "TX",
+      VssTypeId: SubscriptionDetailType.Yes,
+      Value: "Ja",
+    },
+    {
+      VssDesignation: "Listbox select",
+      VssStyle: "LB",
+      DropdownItems: [
+        { Key: 1, Value: "Apple", IsActive: true },
+        { Key: 2, Value: "Pear", IsActive: true },
+        { Key: 3, Value: "Banana", IsActive: false },
+      ],
+      ShowAsRadioButtons: false,
+      Value: 2,
+    },
+    {
+      VssDesignation: "Listbox radios",
+      VssStyle: "LB",
+      DropdownItems: [
+        { Key: 1, Value: "Apple", IsActive: true },
+        { Key: 2, Value: "Pear", IsActive: true },
+        { Key: 3, Value: "Banana", IsActive: false },
+      ],
+      ShowAsRadioButtons: true,
+      Value: 2,
+    },
+    {
+      VssDesignation: "Combobox",
+      VssStyle: "CB",
+      DropdownItems: [
+        { Key: "Apple", Value: "Apple", IsActive: true },
+        { Key: "Banana", Value: "Banana", IsActive: false },
+        { Key: "Grape", Value: "Grape", IsActive: true },
+        { Key: "Grapefruit", Value: "Grapefruit", IsActive: true },
+        { Key: "Pear", Value: "Pear", IsActive: true },
+      ],
+      Value: "Strawberry",
+    },
+  ].map((detail, i) => ({
+    ...detail,
+    Id: String(i + 1),
+  }));
+  subscriptionDetailsSignals = this.getSubscriptionDetailSignals();
+
+  subscriptionDetailsReadonly = this.subscriptionDetails.map((detail) => ({
+    ...detail,
+    VssInternet: "R",
+  }));
+
+  subscriptionDetailsRequired = this.subscriptionDetails.map((detail) => ({
+    ...detail,
+    VssInternet: "M",
+  }));
+
+  build(detail: Partial<SubscriptionDetail>): SubscriptionDetail {
+    return {
+      Id: "1",
+      SubscriptionId: 1,
+      VssId: 1,
+      EventId: 1,
+      IdPerson: 1,
+      DropdownItems: [],
+      ShowAsRadioButtons: false,
+      VssType: "",
+      VssTypeId: SubscriptionDetailType.ShortText,
+      VssStyle: "TX",
+      VssInternet: "E",
+      VssDesignation: "",
+      Tooltip: detail.VssDesignation ? `${detail.VssDesignation} Tooltip` : "",
+      Value: null,
+      Sort: "",
+      ...detail,
+    };
+  }
+
+  private getSubscriptionDetailSignals(): Dict<
+    WritableSignal<SubscriptionDetail>
+  > {
+    return this.subscriptionDetails.reduce(
+      (acc, detail) => ({
+        ...acc,
+        [detail.Id ?? ""]: signal(this.build(detail)),
+      }),
+      {} as Dict<WritableSignal<SubscriptionDetail>>,
+    );
+  }
+}

--- a/src/app/kitchensink/kitchensink.routes.ts
+++ b/src/app/kitchensink/kitchensink.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from "@angular/router";
+import { KitchensinkComponent } from "./components/kitchensink/kitchensink.component";
+
+export const KITCHENSINK_ROUTES: Routes = [
+  {
+    path: "",
+    component: KitchensinkComponent,
+  },
+];

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-combobox.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-combobox.component.ts
@@ -1,0 +1,102 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  computed,
+  input,
+  model,
+  output,
+  viewChild,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { NgbTypeahead, NgbTypeaheadModule } from "@ng-bootstrap/ng-bootstrap";
+import {
+  OperatorFunction,
+  Subject,
+  distinctUntilChanged,
+  map,
+  takeUntil,
+} from "rxjs";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-combobox",
+  imports: [FormsModule, NgbTypeaheadModule],
+  template: `
+    <input
+      #input
+      class="form-control"
+      type="text"
+      [id]="id()"
+      [disabled]="readonly()"
+      [value]="detail().Value"
+      [ngbTypeahead]="search"
+      (input)="onChange($event)"
+      (blur)="onBlur()"
+    />
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailComboboxComponent
+  implements AfterViewInit, OnDestroy
+{
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+  items = computed(() =>
+    this.detail().DropdownItems?.filter((item) => item.IsActive),
+  );
+
+  private typeahead = viewChild.required(NgbTypeahead);
+  private destroy$ = new Subject<void>();
+
+  ngAfterViewInit(): void {
+    this.typeahead()
+      .selectItem.pipe(takeUntil(this.destroy$))
+      .subscribe(({ item }) => this.onSelect(item));
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  search: OperatorFunction<string, readonly string[]> = (term$) =>
+    term$.pipe(distinctUntilChanged(), map(this.findSuggestions.bind(this)));
+
+  onChange(event: Event): void {
+    const { value } = event.target as HTMLInputElement;
+    this.updateDetailValue(value || null);
+  }
+
+  onBlur(): void {
+    this.commit.emit(this.detail());
+  }
+
+  onSelect(value: string): void {
+    this.updateDetailValue(value);
+    this.commit.emit(this.detail());
+  }
+
+  private findSuggestions(value: string): string[] {
+    if (value.length < 2) return [];
+
+    const term = value.toLowerCase();
+
+    return (this.items() ?? [])
+      .filter((item) => item.Value.toLowerCase().includes(term))
+      .slice(0, 10)
+      .map((item) => item.Value);
+  }
+
+  private updateDetailValue(value: SubscriptionDetail["Value"]) {
+    this.detail.set({
+      ...this.detail(),
+      Value: value,
+    });
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-datefield.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-datefield.component.ts
@@ -1,0 +1,109 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  computed,
+  input,
+  model,
+  output,
+  viewChild,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import {
+  NgbDateAdapter,
+  NgbDateParserFormatter,
+  NgbInputDatepicker,
+} from "@ng-bootstrap/ng-bootstrap";
+import { TranslatePipe } from "@ngx-translate/core";
+import { isValid, parse } from "date-fns";
+import { Subject, takeUntil } from "rxjs";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+import { DateParserFormatter } from "../../services/date-parser-formatter";
+import { DateStringAdapter } from "../../services/date-string-adapter.service";
+
+const DATE_FORMAT = "dd.MM.yyyy";
+
+@Component({
+  selector: "bkd-subscription-detail-datefield",
+  imports: [FormsModule, NgbInputDatepicker, TranslatePipe],
+  providers: [
+    { provide: NgbDateAdapter, useClass: DateStringAdapter },
+    { provide: NgbDateParserFormatter, useClass: DateParserFormatter },
+  ],
+  template: `
+    <div class="input-group">
+      <span class="input-group-text" [id]="id()"
+        ><i class="material-icons">calendar_today</i></span
+      >
+      <input
+        class="form-control"
+        type="text"
+        ngbDatepicker
+        #dp="ngbDatepicker"
+        [id]="id()"
+        [placeholder]="'shared.date-select.default-placeholder' | translate"
+        [disabled]="readonly()"
+        [ngModel]="value()"
+        (ngModelChange)="onChange($event)"
+        (blur)="onBlur()"
+        (click)="dp.toggle()"
+      />
+    </div>
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailDatefieldComponent
+  implements AfterViewInit, OnDestroy
+{
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+  value = computed(() =>
+    this.detail().Value ? String(this.detail().Value) : null,
+  );
+
+  private datepicker = viewChild.required(NgbInputDatepicker);
+  private destroy$ = new Subject<void>();
+
+  ngAfterViewInit(): void {
+    this.datepicker()
+      .dateSelect.pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.onSelect());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onChange(value: Option<string>): void {
+    this.updateDetailValue(value);
+  }
+
+  onBlur(): void {
+    // To not overwrite the user's input, while editing the date string, the
+    // value can temporarlily be an invalid string. In this case, we set it to
+    // `null` on blur.
+    const date = parse(String(this.detail().Value), DATE_FORMAT, new Date());
+    if (!isValid(date)) {
+      this.updateDetailValue(null);
+    }
+
+    this.commit.emit(this.detail());
+  }
+
+  onSelect(): void {
+    this.commit.emit(this.detail());
+  }
+
+  private updateDetailValue(value: SubscriptionDetail["Value"]) {
+    this.detail.set({
+      ...this.detail(),
+      Value: value,
+    });
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-description.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-description.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-description",
+  imports: [],
+  template: ` <div [id]="id()">{{ detail().Value }}</div> `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailDescriptionComponent {
+  detail = input.required<SubscriptionDetail>();
+  id = input.required<string>();
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-field.component.spec.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-field.component.spec.ts
@@ -1,0 +1,858 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import {
+  SubscriptionDetail,
+  SubscriptionDetailType,
+} from "../../models/subscription.model";
+import { SubscriptionDetailFieldComponent } from "./subscription-detail-field.component";
+
+describe("SubscriptionDetailFieldComponent", () => {
+  let component: SubscriptionDetailFieldComponent;
+  let fixture: ComponentFixture<SubscriptionDetailFieldComponent>;
+  let element: HTMLElement;
+  let commitCallback: jasmine.Spy;
+  let detail: SubscriptionDetail;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [SubscriptionDetailFieldComponent],
+      }),
+    ).compileComponents();
+
+    fixture = TestBed.createComponent(SubscriptionDetailFieldComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement.nativeElement;
+
+    commitCallback = jasmine.createSpy("commitCallback");
+    component.commit.subscribe(commitCallback);
+  });
+
+  describe("heading", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Heading",
+        Id: "1",
+        VssStyle: "HE",
+      });
+    });
+
+    it("renders heading text", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-heading");
+      expect(element.textContent).toContain("Heading");
+    });
+  });
+
+  describe("description", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Description",
+        VssStyle: "BE",
+        Value:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      });
+    });
+
+    it("renders description with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-description");
+      expectLabel("Description");
+
+      expect(element.textContent).toContain(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      );
+    });
+
+    it("renders description without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-description");
+      expectNoLabel();
+
+      expect(element.textContent).toContain(
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      );
+    });
+  });
+
+  describe("text field", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Text field",
+        VssTypeId: SubscriptionDetailType.ShortText,
+        VssStyle: "TX",
+        Value: "Lorem ipsum",
+      });
+    });
+
+    it("renders text field with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectLabel("Text field");
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("Lorem ipsum");
+    });
+
+    it("renders text field without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectNoLabel();
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("Lorem ipsum");
+    });
+
+    it("emits value change on input & commit on blur", async () => {
+      await render();
+
+      const input = getInput();
+      dispatchEvent(input, "input", "New value");
+      expectChange("New value");
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit("New value");
+    });
+  });
+
+  describe("integer field", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Integer field",
+        VssTypeId: SubscriptionDetailType.Int,
+        VssStyle: "TX",
+        Value: 42,
+      });
+    });
+
+    it("renders number field with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectLabel("Integer field");
+
+      const input = getInput();
+      expect(input.type).toBe("number");
+      expect(input.value).toBe("42");
+    });
+
+    it("renders number field without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectNoLabel();
+
+      const input = getInput();
+      expect(input.type).toBe("number");
+      expect(input.value).toBe("42");
+    });
+
+    it("emits value change on input & commit on blur", async () => {
+      await render();
+
+      const input = element.querySelector<HTMLInputElement>("input")!;
+      dispatchEvent(input, "input", "123");
+      expectChange(123);
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit(123);
+    });
+
+    it("does not allow to enter a float value", async () => {
+      await render();
+
+      const input = element.querySelector<HTMLInputElement>("input")!;
+      dispatchEvent(input, "input", "123.45");
+      expectChange(123);
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit(123);
+    });
+
+    it("does not allow to enter an alpha value", async () => {
+      await render();
+
+      const input = element.querySelector<HTMLInputElement>("input")!;
+      dispatchEvent(input, "input", "Lorem ipsum");
+      expectChange(null);
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit(null);
+    });
+  });
+
+  describe("currency field", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Currency field",
+        VssTypeId: SubscriptionDetailType.Currency,
+        VssStyle: "TX",
+        Value: "12.30",
+      });
+    });
+
+    it("renders number field with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectLabel("Currency field");
+
+      const input = getInput();
+      expect(input.type).toBe("number");
+      expect(input.value).toBe("12.30");
+    });
+
+    it("renders number field without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-textfield");
+      expectNoLabel();
+
+      const input = getInput();
+      expect(input.type).toBe("number");
+      expect(input.value).toBe("12.30");
+    });
+
+    it("emits value change on input & commit on blur, formatting the value with two decimals", async () => {
+      await render();
+
+      const input = getInput();
+      dispatchEvent(input, "input", "123");
+      expectChange("123");
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit("123.00");
+    });
+  });
+
+  describe("textarea", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Textarea",
+        VssTypeId: SubscriptionDetailType.Text,
+        VssStyle: "TX",
+        Value: "Lorem ipsum",
+      });
+    });
+
+    it("renders textarea with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-textarea");
+      expectLabel("Textarea");
+
+      const textarea = getTextarea();
+      expect(textarea.value).toBe("Lorem ipsum");
+    });
+
+    it("renders textarea without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-textarea");
+      expectNoLabel();
+
+      const textarea = getTextarea();
+      expect(textarea.value).toBe("Lorem ipsum");
+    });
+
+    it("emits value change on input & commit on blur", async () => {
+      await render();
+
+      const textarea = getTextarea();
+      dispatchEvent(textarea, "input", "New value");
+      expectChange("New value");
+      expectNoCommit();
+
+      dispatchEvent(textarea, "blur");
+      expectCommit("New value");
+    });
+  });
+
+  describe("date field", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Date field",
+        VssTypeId: SubscriptionDetailType.Date,
+        VssStyle: "TX",
+        Value: "23.01.2000",
+      });
+    });
+
+    it("renders datepicker field with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-datefield");
+      expectLabel("Date field");
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("23.01.2000");
+    });
+
+    it("renders datepicker field without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-datefield");
+      expectNoLabel();
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("23.01.2000");
+    });
+
+    it("emits value change on input & commit on blur", async () => {
+      await render();
+
+      const input = getInput();
+      dispatchEvent(input, "input", "24.01.2000");
+      expectChange("24.01.2000");
+
+      dispatchEvent(input, "blur");
+      expectCommit("24.01.2000");
+    });
+
+    it("emits value change on input & commit on blur, resetting value to null for invalid date", async () => {
+      await render();
+
+      const input = getInput();
+      dispatchEvent(input, "input", "24.01");
+      expectChange("24.01");
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit(null);
+    });
+
+    it("emits value change & commit on select", async () => {
+      await render();
+
+      const input = getInput();
+
+      // Open datepicker
+      input.click();
+
+      // Select the 24.01.2000 in the datepicker dropdown
+      const days = Array.from(
+        element.querySelectorAll<HTMLElement>(
+          "ngb-datepicker .ngb-dp-day .btn-light",
+        ),
+      );
+      const day = days.find((day) => day.textContent?.trim() === "24");
+      day?.click();
+
+      expectChange("24.01.2000");
+      expectCommit("24.01.2000");
+    });
+  });
+
+  describe("yes/no", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Yes/no",
+        VssTypeId: SubscriptionDetailType.YesNo,
+        VssStyle: "TX",
+        Value: "Ja",
+      });
+    });
+
+    describe("checkbox", () => {
+      beforeEach(() => {
+        detail.ShowAsRadioButtons = false;
+      });
+
+      it("renders checkbox with label", async () => {
+        await render();
+
+        expectComponent("bkd-subscription-detail-yesno");
+        expectLabel("Yes/no");
+
+        const checkboxes = getCheckboxes();
+        expect(checkboxes).toHaveSize(1);
+        expect(checkboxes[0].checked).toBeTruthy();
+      });
+
+      it("renders initial value 'Nein'", async () => {
+        detail.Value = "Nein";
+        await render();
+
+        const checkboxes = getCheckboxes();
+        expect(checkboxes).toHaveSize(1);
+        expect(checkboxes[0].checked).toBeFalsy();
+      });
+
+      it("renders checkbox without label", async () => {
+        fixture.componentRef.setInput("hideLabel", true);
+        await render();
+
+        expectComponent("bkd-subscription-detail-yesno");
+        expectNoLabel();
+
+        const checkboxes = getCheckboxes();
+        expect(checkboxes).toHaveSize(1);
+        expect(checkboxes[0].checked).toBeTruthy();
+      });
+
+      it("emits value change & commit on change", async () => {
+        await render();
+
+        const [checkbox] = getCheckboxes();
+        checkbox.click();
+        expectChange("Nein");
+        expectCommit("Nein");
+
+        resetCommit();
+        checkbox.click();
+        expectChange("Ja");
+        expectCommit("Ja");
+      });
+    });
+
+    describe("radios", () => {
+      beforeEach(() => {
+        detail.ShowAsRadioButtons = true;
+      });
+
+      it("renders radios with label", async () => {
+        await render();
+
+        expectComponent("bkd-subscription-detail-yesno");
+        expectLabel("Yes/no");
+
+        const radios = getRadios();
+        expect(
+          radios.map((radio) => ({
+            label: (radio.labels ?? [])[0]?.textContent?.trim(),
+            checked: radio.checked,
+          })),
+        ).toEqual([
+          { label: "evaluation.values.yes", checked: true },
+          { label: "evaluation.values.no", checked: false },
+        ]);
+      });
+
+      it("renders initial value 'Nein'", async () => {
+        detail.Value = "Nein";
+        await render();
+
+        const radios = getRadios();
+        expect(
+          radios.map((radio) => ({
+            label: (radio.labels ?? [])[0]?.textContent?.trim(),
+            checked: radio.checked,
+          })),
+        ).toEqual([
+          { label: "evaluation.values.yes", checked: false },
+          { label: "evaluation.values.no", checked: true },
+        ]);
+      });
+
+      it("renders checkbox without label", async () => {
+        fixture.componentRef.setInput("hideLabel", true);
+        await render();
+
+        expectComponent("bkd-subscription-detail-yesno");
+        const labels = Array.from(element.querySelectorAll("label"));
+        expect(labels).toHaveSize(2);
+
+        const radios = getRadios();
+        expect(
+          radios.map((radio) => ({
+            label: (radio.labels ?? [])[0]?.textContent?.trim(),
+            checked: radio.checked,
+          })),
+        ).toEqual([
+          { label: "evaluation.values.yes", checked: true },
+          { label: "evaluation.values.no", checked: false },
+        ]);
+      });
+
+      it("emits value change & commit on change", async () => {
+        await render();
+
+        const radios = getRadios();
+        radios[1].click();
+        expectChange("Nein");
+        expectCommit("Nein");
+
+        resetCommit();
+        radios[0].click();
+        expectChange("Ja");
+        expectCommit("Ja");
+      });
+    });
+  });
+
+  describe("yes", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Yes",
+        VssTypeId: SubscriptionDetailType.Yes,
+        VssStyle: "TX",
+        Value: "Ja",
+      });
+    });
+
+    it("renders checkbox with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-yesno");
+      expectLabel("Yes");
+
+      const checkboxes = getCheckboxes();
+      expect(checkboxes).toHaveSize(1);
+      expect(checkboxes[0].checked).toBeTruthy();
+    });
+
+    it("renders initial value null", async () => {
+      detail.Value = null;
+      await render();
+
+      const checkboxes = getCheckboxes();
+      expect(checkboxes).toHaveSize(1);
+      expect(checkboxes[0].checked).toBeFalsy();
+    });
+
+    it("renders checkbox without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-yesno");
+      expectNoLabel();
+
+      const checkboxes = getCheckboxes();
+      expect(checkboxes).toHaveSize(1);
+      expect(checkboxes[0].checked).toBeTruthy();
+    });
+
+    it("emits value change & commit on change", async () => {
+      await render();
+
+      const [checkbox] = getCheckboxes();
+      checkbox.click();
+      expectChange(null);
+      expectCommit(null);
+
+      resetCommit();
+      checkbox.click();
+      expectChange("Ja");
+      expectCommit("Ja");
+    });
+  });
+
+  describe("listbox", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Listbox",
+        VssStyle: "LB",
+        DropdownItems: [
+          { Key: 1, Value: "Apple", IsActive: true },
+          { Key: 2, Value: "Pear", IsActive: true },
+          { Key: 3, Value: "Banana", IsActive: false },
+        ],
+        Value: 2,
+      });
+    });
+
+    describe("select", () => {
+      beforeEach(() => {
+        detail.ShowAsRadioButtons = false;
+      });
+
+      it("renders select with label", async () => {
+        await render();
+
+        expectComponent("bkd-subscription-detail-listbox");
+        expectLabel("Listbox");
+
+        const select = getSelect();
+        expect(select.value).toBe("2");
+
+        const options = getSelectOptions();
+        expect(options.map((o) => o.textContent?.trim())).toEqual([
+          "Apple",
+          "Pear",
+        ]);
+      });
+
+      it("renders select without label", async () => {
+        fixture.componentRef.setInput("hideLabel", true);
+        await render();
+
+        expectComponent("bkd-subscription-detail-listbox");
+        expectNoLabel();
+
+        const select = getSelect();
+        expect(select.value).toBe("2");
+
+        const options = getSelectOptions();
+        expect(options.map((o) => o.textContent?.trim())).toEqual([
+          "Apple",
+          "Pear",
+        ]);
+      });
+
+      it("emits value change & commit on change", async () => {
+        await render();
+
+        const select = getSelect();
+        dispatchEvent(select, "change", "1");
+        expectChange(1);
+        expectCommit(1);
+      });
+    });
+
+    describe("radios", () => {
+      beforeEach(() => {
+        detail.ShowAsRadioButtons = true;
+      });
+
+      it("renders radio buttons with label", async () => {
+        await render();
+
+        expectComponent("bkd-subscription-detail-listbox");
+        expectLabel("Listbox");
+
+        const radios = getRadios();
+        expect(
+          radios.map((radio) => ({
+            label: (radio.labels ?? [])[0]?.textContent?.trim(),
+            checked: radio.checked,
+          })),
+        ).toEqual([
+          { label: "Apple", checked: false },
+          { label: "Pear", checked: true },
+        ]);
+      });
+
+      it("renders radio buttons without label", async () => {
+        fixture.componentRef.setInput("hideLabel", true);
+        await render();
+
+        expectComponent("bkd-subscription-detail-listbox");
+        const labels = Array.from(element.querySelectorAll("label"));
+        expect(labels).toHaveSize(2);
+
+        const radios = getRadios();
+        expect(
+          radios.map((radio) => ({
+            label: (radio.labels ?? [])[0]?.textContent?.trim(),
+            checked: radio.checked,
+          })),
+        ).toEqual([
+          { label: "Apple", checked: false },
+          { label: "Pear", checked: true },
+        ]);
+      });
+
+      it("emits value change & commit on change", async () => {
+        await render();
+
+        const radios = getRadios();
+        radios[0].click();
+        expectChange(1);
+        expectCommit(1);
+      });
+    });
+  });
+
+  describe("combobox", () => {
+    beforeEach(() => {
+      detail = build({
+        VssDesignation: "Combobox",
+        VssStyle: "CB",
+        DropdownItems: [
+          { Key: "Grape", Value: "Grape", IsActive: true },
+          { Key: "Grapefruit", Value: "Grapefruit", IsActive: true },
+          {
+            Key: "Grapefruit juice",
+            Value: "Grapefruit juice",
+            IsActive: false,
+          },
+        ],
+        Value: "Strawberry",
+      });
+    });
+
+    it("renders text field with label", async () => {
+      await render();
+
+      expectComponent("bkd-subscription-detail-combobox");
+      expectLabel("Combobox");
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("Strawberry");
+    });
+
+    it("renders text field without label", async () => {
+      fixture.componentRef.setInput("hideLabel", true);
+      await render();
+
+      expectComponent("bkd-subscription-detail-combobox");
+      expectNoLabel();
+
+      const input = getInput();
+      expect(input.type).toBe("text");
+      expect(input.value).toBe("Strawberry");
+    });
+
+    it("emits value change on input & commit on blur", async () => {
+      await render();
+
+      const input = getInput();
+      dispatchEvent(input, "input", "Cherry");
+      expectChange("Cherry");
+      expectNoCommit();
+
+      dispatchEvent(input, "blur");
+      expectCommit("Cherry");
+    });
+
+    it("displays typeahead suggestions & emits value change & commit on select", async () => {
+      await render();
+
+      const input = getInput();
+
+      // Type something to trigger typeahead dropdown
+      dispatchEvent(input, "input", "grape");
+
+      // Typeahead displays suggestions, matching case insensitive
+      const suggestions = Array.from(
+        element.querySelectorAll<HTMLButtonElement>(
+          "ngb-typeahead-window button",
+        ),
+      );
+      expect(suggestions.map((c) => c.textContent?.trim())).toEqual([
+        "Grape",
+        "Grapefruit",
+      ]);
+
+      // Choose value from typeahead list
+      suggestions[1].click();
+      expectChange("Grapefruit");
+      expectCommit("Grapefruit");
+    });
+  });
+
+  function expectComponent(selector: string): void {
+    expect(element.querySelector(selector)).not.toBeNull();
+  }
+
+  function expectLabel(text: string): void {
+    const label = element.querySelector("label");
+    expect(label?.textContent).toContain(text);
+  }
+
+  function expectNoLabel(): void {
+    expect(element.querySelector("label")).toBeNull();
+  }
+
+  function expectChange(value: SubscriptionDetail["Value"]): void {
+    expect(component.detail()).toEqual({ ...detail, Value: value });
+  }
+
+  function expectCommit(value: SubscriptionDetail["Value"]): void {
+    expect(component.detail()).toEqual({ ...detail, Value: value });
+
+    expect(commitCallback).toHaveBeenCalledTimes(1);
+    expect(commitCallback.calls.mostRecent().args[0]).toEqual({
+      ...detail,
+      Value: value,
+    });
+  }
+
+  function expectNoCommit(): void {
+    expect(commitCallback).not.toHaveBeenCalled();
+  }
+
+  function resetCommit(): void {
+    commitCallback.calls.reset();
+  }
+
+  function getInput(): HTMLInputElement {
+    const input = element.querySelector("input");
+    expect(input).not.toBeNull();
+    return input!;
+  }
+
+  function getTextarea(): HTMLTextAreaElement {
+    const textarea = element.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    return textarea!;
+  }
+
+  function getSelect(): HTMLSelectElement {
+    const select = element.querySelector("select");
+    expect(select).not.toBeNull();
+    return select!;
+  }
+
+  function getSelectOptions(): ReadonlyArray<HTMLOptionElement> {
+    return Array.from(element.querySelectorAll("select option"));
+  }
+
+  function getRadios(): ReadonlyArray<HTMLInputElement> {
+    return Array.from(element.querySelectorAll("input[type='radio']"));
+  }
+
+  function getCheckboxes(): ReadonlyArray<HTMLInputElement> {
+    return Array.from(element.querySelectorAll("input[type='checkbox']"));
+  }
+
+  async function render() {
+    fixture.componentRef.setInput("detail", detail);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function dispatchEvent(
+    element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+    eventType: string,
+    value?: string,
+  ): void {
+    const inputEvent = new Event(eventType);
+    if (value !== undefined) {
+      element.value = value;
+    }
+    element.dispatchEvent(inputEvent);
+  }
+
+  function build(detail: Partial<SubscriptionDetail>): SubscriptionDetail {
+    return {
+      Id: "1",
+      SubscriptionId: 1,
+      VssId: 1,
+      EventId: 1,
+      IdPerson: 1,
+      DropdownItems: [],
+      ShowAsRadioButtons: false,
+      VssType: "",
+      VssTypeId: SubscriptionDetailType.ShortText,
+      VssStyle: "TX",
+      VssInternet: "E",
+      VssDesignation: "",
+      Tooltip: "",
+      Value: null,
+      Sort: "",
+      ...detail,
+    };
+  }
+});

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-field.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-field.component.ts
@@ -1,0 +1,147 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  computed,
+  input,
+  model,
+  output,
+} from "@angular/core";
+import {
+  SubscriptionDetail,
+  SubscriptionDetailType,
+} from "src/app/shared/models/subscription.model";
+import { SubscriptionDetailComboboxComponent } from "./subscription-detail-combobox.component";
+import { SubscriptionDetailDatefieldComponent } from "./subscription-detail-datefield.component";
+import { SubscriptionDetailDescriptionComponent } from "./subscription-detail-description.component";
+import { SubscriptionDetailHeadingComponent } from "./subscription-detail-heading.component";
+import { SubscriptionDetailLabelComponent } from "./subscription-detail-label.component";
+import { SubscriptionDetailListboxComponent } from "./subscription-detail-listbox.component";
+import { SubscriptionDetailTextareaComponent } from "./subscription-detail-textarea.component";
+import { SubscriptionDetailTextfieldComponent } from "./subscription-detail-textfield.component";
+import { SubscriptionDetailYesNoComponent } from "./subscription-detail-yesno.component";
+
+@Component({
+  selector: "bkd-subscription-detail-field",
+  imports: [
+    SubscriptionDetailHeadingComponent,
+    SubscriptionDetailDescriptionComponent,
+    SubscriptionDetailComboboxComponent,
+    SubscriptionDetailListboxComponent,
+    SubscriptionDetailTextfieldComponent,
+    SubscriptionDetailTextareaComponent,
+    SubscriptionDetailYesNoComponent,
+    SubscriptionDetailDatefieldComponent,
+    SubscriptionDetailLabelComponent,
+  ],
+  template: `
+    @let id = detail().Id + "-" + detail().IdPerson;
+    @if (detail().VssStyle !== "HE" && !hideLabel()) {
+      <bkd-subscription-detail-label
+        [detail]="detail()"
+        [id]="id"
+        [hideLabel]="hideLabel()"
+        [style.min-width]="layout() === 'horizontal' ? labelWidth() : ''"
+      ></bkd-subscription-detail-label>
+    }
+
+    @switch (detail().VssStyle) {
+      @case ("HE") {
+        <bkd-subscription-detail-heading
+          [detail]="detail()"
+        ></bkd-subscription-detail-heading>
+      }
+      @case ("BE") {
+        <bkd-subscription-detail-description
+          [detail]="detail()"
+          [id]="id"
+        ></bkd-subscription-detail-description>
+      }
+      @case ("CB") {
+        <bkd-subscription-detail-combobox
+          [(detail)]="detail"
+          [id]="id"
+          (commit)="commit.emit($event)"
+        ></bkd-subscription-detail-combobox>
+      }
+      @case ("LB") {
+        <bkd-subscription-detail-listbox
+          [(detail)]="detail"
+          [id]="id"
+          [layout]="layout()"
+          (commit)="commit.emit($event)"
+        ></bkd-subscription-detail-listbox>
+      }
+      @case ("TX") {
+        @if (isTextField()) {
+          <bkd-subscription-detail-textfield
+            [(detail)]="detail"
+            [id]="id"
+            (commit)="commit.emit($event)"
+          ></bkd-subscription-detail-textfield>
+        } @else if (isDate()) {
+          <bkd-subscription-detail-datefield
+            [(detail)]="detail"
+            [id]="id"
+            (commit)="commit.emit($event)"
+          ></bkd-subscription-detail-datefield>
+        } @else if (isTextarea()) {
+          <bkd-subscription-detail-textarea
+            [(detail)]="detail"
+            [id]="id"
+            (commit)="commit.emit($event)"
+          ></bkd-subscription-detail-textarea>
+        } @else if (isYesNo()) {
+          <bkd-subscription-detail-yesno
+            [(detail)]="detail"
+            [id]="id"
+            [layout]="layout()"
+            (commit)="commit.emit($event)"
+          ></bkd-subscription-detail-yesno>
+        }
+      }
+    }
+  `,
+  styles: `
+    :host {
+      display: flex;
+      column-gap: 1rem;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailFieldComponent {
+  detail = model.required<SubscriptionDetail>();
+  hideLabel = input(false);
+  layout = input<"vertical" | "horizontal">("vertical");
+  labelWidth = input("33%");
+  commit = output<SubscriptionDetail>();
+
+  isTextField = computed(
+    () =>
+      this.detail()?.VssTypeId === SubscriptionDetailType.ShortText ||
+      this.detail()?.VssTypeId === SubscriptionDetailType.Int ||
+      this.detail()?.VssTypeId === SubscriptionDetailType.Currency,
+  );
+  isTextarea = computed(
+    () => this.detail()?.VssTypeId === SubscriptionDetailType.Text,
+  );
+  isYesNo = computed(
+    () =>
+      this.detail()?.VssTypeId === SubscriptionDetailType.YesNo ||
+      this.detail()?.VssTypeId === SubscriptionDetailType.Yes,
+  );
+  isDate = computed(
+    () => this.detail()?.VssTypeId === SubscriptionDetailType.Date,
+  );
+
+  @HostBinding("class.flex-column")
+  get flexColumn() {
+    return this.layout() === "vertical";
+  }
+
+  @HostBinding("class.flex-row")
+  get flexRow() {
+    return this.layout() === "horizontal";
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-heading.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-heading.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-heading",
+  imports: [NgbTooltipModule],
+  template: `
+    <div [ngbTooltip]="detail().Tooltip">
+      {{ detail().VssDesignation }}
+    </div>
+  `,
+  styles: `
+    :host {
+      font-weight: bold;
+    }
+    div {
+      display: inline-flex; /* Fix tooltip placement */
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailHeadingComponent {
+  detail = input.required<SubscriptionDetail>();
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-label.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-label.component.ts
@@ -1,0 +1,35 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+} from "@angular/core";
+import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-label",
+  imports: [NgbTooltipModule],
+  template: `
+    @if (!hideLabel()) {
+      <label
+        [attr.for]="id()"
+        class="form-label"
+        [ngbTooltip]="detail().Tooltip"
+      >
+        {{ detail().VssDesignation }}
+        {{ required() ? "*" : "" }}
+      </label>
+    }
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailLabelComponent {
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  hideLabel = input.required<boolean>();
+
+  required = computed(() => this.detail().VssInternet === "M");
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-listbox.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-listbox.component.ts
@@ -1,0 +1,87 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-listbox",
+  imports: [FormsModule],
+  template: `
+    @if (asRadios()) {
+      <div
+        [id]="id()"
+        class="radios d-flex"
+        [class.flex-row]="layout() === 'horizontal'"
+        [class.flex-column]="layout() === 'vertical'"
+      >
+        @for (item of items(); track item.Key) {
+          @let itemId = id() + "-" + item.Key;
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="radio"
+              [name]="id()"
+              [id]="itemId"
+              [value]="item.Key"
+              [disabled]="readonly()"
+              [ngModel]="detail().Value"
+              (ngModelChange)="onChange(item.Key)"
+            />
+            <label class="form-check-label" [attr.for]="itemId">
+              {{ item.Value }}
+            </label>
+          </div>
+        }
+      </div>
+    } @else {
+      <select
+        class="form-select"
+        [id]="id()"
+        [disabled]="readonly()"
+        [ngModel]="detail().Value"
+        (ngModelChange)="onChange($event)"
+      >
+        @for (item of items(); track item.Key) {
+          <option [value]="item.Key">
+            {{ item.Value }}
+          </option>
+        }
+        >
+      </select>
+    }
+  `,
+  styles: `
+    .radios.flex-row {
+      gap: 1rem;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailListboxComponent {
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  layout = input.required<"vertical" | "horizontal">();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+  asRadios = computed(() => this.detail().ShowAsRadioButtons);
+  items = computed(() =>
+    this.detail().DropdownItems?.filter((item) => item.IsActive),
+  );
+
+  onChange(value: SubscriptionDetail["Value"]): void {
+    const item = this.items()?.find((item) => item.Key == value);
+    const detail: SubscriptionDetail = {
+      ...this.detail(),
+      Value: item?.Key ?? null,
+    };
+    this.detail.set(detail);
+    this.commit.emit(detail);
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-textarea.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-textarea.component.ts
@@ -1,0 +1,44 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+} from "@angular/core";
+import { SubscriptionDetail } from "src/app/shared/models/subscription.model";
+import { TextareaAutosizeDirective } from "../../directives/textarea-autosize.directive";
+
+@Component({
+  selector: "bkd-subscription-detail-textarea",
+  imports: [TextareaAutosizeDirective],
+  template: `
+    <textarea
+      class="form-control"
+      [id]="id()"
+      [value]="detail().Value"
+      [disabled]="readonly()"
+      (input)="onInput($event)"
+      (blur)="onBlur()"
+      bkdTextareaAutosize
+    ></textarea>
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailTextareaComponent {
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+
+  onInput(event: Event) {
+    const { value } = event.target as HTMLTextAreaElement;
+    this.detail.set({ ...this.detail(), Value: value || null });
+  }
+
+  onBlur() {
+    this.commit.emit(this.detail());
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-textfield.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-textfield.component.ts
@@ -1,0 +1,108 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  input,
+  model,
+  output,
+  viewChild,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import {
+  SubscriptionDetail,
+  SubscriptionDetailType,
+} from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-textfield",
+  imports: [FormsModule],
+  template: `
+    <input
+      #input
+      class="form-control"
+      [id]="id()"
+      [type]="fieldType()"
+      [disabled]="readonly()"
+      [value]="detail().Value"
+      [step]="isCurrency() ? '0.05' : '1'"
+      (input)="onChange($event)"
+      (blur)="onBlur()"
+    />
+  `,
+  styles: `
+    input[type="number"] {
+      max-width: 15ch;
+      min-width: 10ch;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailTextfieldComponent {
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+  isInt = computed(
+    () => this.detail().VssTypeId === SubscriptionDetailType.Int,
+  );
+  isCurrency = computed(
+    () => this.detail().VssTypeId === SubscriptionDetailType.Currency,
+  );
+  fieldType = computed(() =>
+    this.isInt() || this.isCurrency() ? "number" : "text",
+  );
+
+  private input = viewChild.required<ElementRef<HTMLInputElement>>("input");
+
+  onChange(event: Event) {
+    const { value: rawValue } = event.target as HTMLInputElement;
+    const value = this.normalizeValueOnChange(rawValue);
+
+    // For int fields, enforce the normalized value (i.e. no decimals or alpha
+    // chars) as value of the input field (apparently, only with the [value]
+    // binding, the normalized value is not applied).
+    if (this.isInt()) {
+      this.input().nativeElement.value = String(value);
+    }
+
+    this.updateDetailValue(value);
+  }
+
+  onBlur() {
+    // Normalize the value such that the currency gets propperly formatted
+    this.updateDetailValue(this.normalizeValueOnBlur(this.detail().Value));
+
+    this.commit.emit(this.detail());
+  }
+
+  private normalizeValueOnChange(value: string): SubscriptionDetail["Value"] {
+    if (value === "") {
+      return null;
+    }
+
+    if (this.isInt()) {
+      return Math.floor(Number(value));
+    }
+
+    return value;
+  }
+
+  private normalizeValueOnBlur(
+    value: SubscriptionDetail["Value"],
+  ): SubscriptionDetail["Value"] {
+    if (value && this.isCurrency()) {
+      return Number(this.detail().Value).toFixed(2);
+    }
+
+    return value;
+  }
+
+  private updateDetailValue(value: SubscriptionDetail["Value"]) {
+    this.detail.set({
+      ...this.detail(),
+      Value: value,
+    });
+  }
+}

--- a/src/app/shared/components/subscription-detail-field/subscription-detail-yesno.component.ts
+++ b/src/app/shared/components/subscription-detail-field/subscription-detail-yesno.component.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { TranslatePipe } from "@ngx-translate/core";
+import {
+  SubscriptionDetail,
+  SubscriptionDetailType,
+} from "src/app/shared/models/subscription.model";
+
+@Component({
+  selector: "bkd-subscription-detail-yesno",
+  imports: [FormsModule, TranslatePipe],
+  template: `
+    @if (yesAndNo() && asRadios()) {
+      <div
+        [id]="id()"
+        class="radios d-flex"
+        [class.flex-row]="layout() === 'horizontal'"
+        [class.flex-column]="layout() === 'vertical'"
+      >
+        @for (option of ["Ja", "Nein"]; track option) {
+          @let itemId = id() + "-" + option;
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="radio"
+              [name]="id()"
+              [id]="itemId"
+              [value]="option"
+              [disabled]="readonly()"
+              [ngModel]="detail().Value"
+              (ngModelChange)="onRadioChange(option)"
+            />
+            <label class="form-check-label" [attr.for]="itemId">
+              @let labelKey =
+                option === "Ja"
+                  ? "evaluation.values.yes"
+                  : "evaluation.values.no";
+              {{ labelKey | translate }}
+            </label>
+          </div>
+        }
+      </div>
+    } @else {
+      <div class="form-check">
+        <input
+          class="form-check-input"
+          type="checkbox"
+          [name]="id()"
+          [id]="id()"
+          [disabled]="readonly()"
+          [ngModel]="detail().Value === 'Ja'"
+          (ngModelChange)="onCheckboxToggle($event)"
+        />
+      </div>
+    }
+  `,
+  styles: `
+    .radios.flex-row {
+      gap: 1rem;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionDetailYesNoComponent {
+  detail = model.required<SubscriptionDetail>();
+  id = input.required<string>();
+  layout = input.required<"vertical" | "horizontal">();
+  commit = output<SubscriptionDetail>();
+
+  readonly = computed(() => this.detail().VssInternet === "R");
+  required = computed(() => this.detail().VssInternet === "M");
+  yesAndNo = computed(
+    () => this.detail().VssTypeId === SubscriptionDetailType.YesNo,
+  );
+  asRadios = computed(() => this.detail().ShowAsRadioButtons);
+
+  onRadioChange(value: SubscriptionDetail["Value"]): void {
+    const detail: SubscriptionDetail = {
+      ...this.detail(),
+      Value: value ?? null,
+    };
+    this.detail.set(detail);
+    this.commit.emit(detail);
+  }
+
+  onCheckboxToggle(checked: boolean): void {
+    const value = checked ? "Ja" : this.yesAndNo() ? "Nein" : null;
+    const detail: SubscriptionDetail = {
+      ...this.detail(),
+      Value: value,
+    };
+    this.detail.set(detail);
+    this.commit.emit(detail);
+  }
+}

--- a/src/app/shared/directives/textarea-autosize.directive.ts
+++ b/src/app/shared/directives/textarea-autosize.directive.ts
@@ -1,0 +1,30 @@
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  HostListener,
+} from "@angular/core";
+
+@Directive({
+  selector: "textarea[bkdTextareaAutosize]",
+})
+export class TextareaAutosizeDirective implements AfterViewInit {
+  constructor(private elementRef: ElementRef) {}
+
+  @HostListener(":input")
+  onInput() {
+    this.resize();
+  }
+
+  ngAfterViewInit() {
+    if (this.elementRef.nativeElement.scrollHeight) {
+      setTimeout(() => this.resize());
+    }
+  }
+
+  resize() {
+    this.elementRef.nativeElement.style.height = "0";
+    this.elementRef.nativeElement.style.height =
+      this.elementRef.nativeElement.scrollHeight + 3 + "px";
+  }
+}

--- a/src/app/shared/models/subscription.model.ts
+++ b/src/app/shared/models/subscription.model.ts
@@ -7,6 +7,9 @@ export enum SubscriptionDetailType {
   Currency = 279,
   ShortText = 290, // → Text in old implementation
   Text = 293, // → MemoText in old implementation
+  YesNo = 291,
+  Yes = 292,
+  Date = 295,
 }
 
 const SubscriptionDetail = t.type({

--- a/src/app/shared/services/date-parser-formatter.ts
+++ b/src/app/shared/services/date-parser-formatter.ts
@@ -5,13 +5,15 @@ import {
 } from "@ng-bootstrap/ng-bootstrap";
 import { format, parse } from "date-fns";
 
+const DATE_FORMAT = "dd.MM.yyyy";
+
 @Injectable()
 export class DateParserFormatter extends NgbDateParserFormatter {
   /**
    * The default implementation uses non-strict type checking and expects `null` to be returned if the value can't be parsed.
    */
   parse(value: string): NgbDateStruct {
-    const date = value ? parse(value, "dd.MM.yyyy", new Date()) : null;
+    const date = value ? parse(value, DATE_FORMAT, new Date()) : null;
     if (date) {
       return {
         year: date.getFullYear(),
@@ -19,14 +21,14 @@ export class DateParserFormatter extends NgbDateParserFormatter {
         day: date.getDate(),
       };
     }
-    return null as unknown as NgbDateStruct;
+    return { year: NaN, month: NaN, day: NaN };
   }
   /**
    * The default implementation uses non-strict type checking and expects an empty string to be returned if the given date is `null`.
    */
   format(date: NgbDateStruct): string {
     return date
-      ? format(new Date(date.year, date.month - 1, date.day), "dd.MM.yyyy")
+      ? format(new Date(date.year, date.month - 1, date.day), DATE_FORMAT)
       : "";
   }
 }

--- a/src/app/shared/services/date-string-adapter.service.ts
+++ b/src/app/shared/services/date-string-adapter.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@angular/core";
+import { NgbDateAdapter, NgbDateStruct } from "@ng-bootstrap/ng-bootstrap";
+import { DateParserFormatter } from "./date-parser-formatter";
+
+@Injectable()
+export class DateStringAdapter extends NgbDateAdapter<string> {
+  private parserFormatter = new DateParserFormatter();
+
+  /**
+   * Converts a date string in the form of 'dd.MM.yyyy' to a `NgbDateStruct`.
+   */
+  fromModel(date: string | null): NgbDateStruct | null {
+    return this.parserFormatter.parse(date ?? "");
+  }
+
+  /**
+   * Converts a `NgbDateStruct` to a date string in the form of 'dd.MM.yyyy'.
+   */
+  toModel(date: NgbDateStruct | null): string | null {
+    if (!date) return null;
+    return this.parserFormatter.format(date);
+  }
+}

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -345,6 +345,10 @@
       "grade": "Note",
       "absences": "Absenzen"
     },
+    "values": {
+      "yes": "Ja",
+      "no": "Nein"
+    },
     "average": "Durchschnitt"
   },
   "dossier": {
@@ -565,6 +569,9 @@
     "typeahead": {
       "default-placeholder": "Suchen..."
     }
+  },
+  "kitchensink": {
+    "title": "Kitchensink"
   },
   "api": {
     "title": "API Debugging"

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -345,6 +345,10 @@
       "grade": "Note",
       "absences": "Absences"
     },
+    "values": {
+      "yes": "Oui",
+      "no": "Non"
+    },
     "average": "Moyenne"
   },
   "dossier": {
@@ -565,5 +569,11 @@
     "typeahead": {
       "default-placeholder": "Rechercher..."
     }
+  },
+  "kitchensink": {
+    "title": "Kitchensink"
+  },
+  "api": {
+    "title": "API Debugging"
   }
 }


### PR DESCRIPTION
#812

Dieser PR fügt die verschiedenen Feldertypen gemäss Subscription Details hinzu. Das Speichern in der Evaluation Table setze ich in einem separaten PR um.

Einstieg ist die `bkd-subscription-detail-field`, über welche ein Feld für ein Subscription Detail gerendered werde kann. Das Rendering der konkreten Inhalte für die einzelnen Feldtypen ist in separate Komponenten ausgelagert. Getestet werden alle Feldtypen in `subscription-detail-field.component.spec.ts`.

- [x] Kitchensink Komponente zum Testen der verschiedenen Feldtypen/-varianten → siehe «Kitchensink» Menüeintrag auf Home resp. http://localhost:4200/#/kitchensink
- [x] Horizontale Darstellung
- [x] Readonly (disabled)
- [x] Markierung der Muss-Felder
- [x] Tooltip-Text beim Label
- [x] Vorbereitung für das Speichern beim Verlassen des Feldes (`commit` Output)
- [x] Anzeige der Felder in der Evaluation Table (noch ohne Speichern)
- Umgesetzte Feldtypen:
  - [x] Heading-Feld
  - [x] Description-Feld
  - [x] Text-Feld (einzeilig)
  - [x] Integer-Feld
  - [x] Currency-Feld
  - [x] Textarea-Feld (mehrzeilig)
  - [x] Datum-Feld
  - [x] Yes/No Checkbox resp. Radios
  - [x] Yes Checkbox
  - [x] Listbox-Select
  - [x] Listbox-Radios
  - [x] Combox (Typeahead)