### PR TITLE
Make subscription detail label same width as student name  #829

### DIFF
--- a/src/app/events/components/evaluation/evaluation-table/evaluation-table-common.scss
+++ b/src/app/events/components/evaluation/evaluation-table/evaluation-table-common.scss
@@ -16,9 +16,7 @@
   );
 
   --student-grade-column-offset: var(--student-name-column-width);
-  --subscription-detail-columns-offset: calc(
-    var(--student-grade-column-offset) + var(--student-grade-column-width)
-  );
+  --subscription-detail-columns-offset: var(--student-name-column-width);
 }
 
 $student-name-width-breakpoint: 1000px;

--- a/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.scss
+++ b/src/app/events/components/evaluation/evaluation-table/evaluation-table.component.scss
@@ -92,14 +92,10 @@ button.criteria-toggle {
     cursor: pointer;
   }
 
-  // Make criteria field labels the same width as the student name and grade columns
+  // Make criteria field labels the same width as the student name
   ::ng-deep {
     bkd-subscription-detail-label {
       min-width: auto !important;
-      // TODO: The --subscription-detail-columns-offset should adapt to whether
-      // the grade column is present or not. Currently, the criteria fields
-      // don't align with the detail columns for events that have no grades but
-      // criteria.
       width: calc(
         var(--subscription-detail-columns-offset) - $spacer
       ) !important;


### PR DESCRIPTION
Ich bin mir mit der Lösung nicht 100%ig sicher, ob ich das erwünschte Verhalten erziele. 

Nach meinem Verständnis muss das `bkd-subscription-detail-label` die gleiche Breite wie `studend-name` haben, unabhängig ob eine Note dargestellt wird oder nicht?! 
