### PR TITLE
Feat/882 disable test status update

### DIFF
--- a/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
+++ b/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
@@ -34,14 +34,15 @@
       <div
         class="d-flex align-items-center justify-content-between test-status"
       >
-        <a
+        <button
+          type="button"
           class="d-flex btn btn-link ps-0 edit"
           title="{{ 'tests.edit' | translate }}"
           (click)="unpublishTest()"
         >
           <i class="material-icons me-1">lock</i>
           <span>{{ "tests.published" | translate }}</span>
-        </a>
+        </button>
         <bkd-caret
           class="expand-mobile"
           (click)="emitToggleHeader()"
@@ -52,14 +53,15 @@
       <div
         class="d-flex align-items-center justify-content-between test-status"
       >
-        <a
+        <button
+          type="button"
           class="d-flex btn btn-link ps-0"
           (click)="publishTest()"
           title="{{ 'tests.publish' | translate }}"
         >
           <i class="material-icons me-1">lock_open</i>
           <span>{{ "tests.not-published" | translate }}</span>
-        </a>
+        </button>
         <bkd-caret
           class="expand-mobile"
           (click)="emitToggleHeader()"

--- a/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
+++ b/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
@@ -37,6 +37,7 @@
         <button
           type="button"
           class="d-flex btn btn-link ps-0 edit"
+          [disabled]="!test.IsOwner"
           title="{{ 'tests.edit' | translate }}"
           (click)="unpublishTest()"
         >
@@ -56,6 +57,7 @@
         <button
           type="button"
           class="d-flex btn btn-link ps-0"
+          [disabled]="!test.IsOwner"
           (click)="publishTest()"
           title="{{ 'tests.publish' | translate }}"
         >

--- a/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
+++ b/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.html
@@ -18,11 +18,11 @@
           <bkd-preserve-line-height>{{
             test.Date | date: "dd.MM.yyyy"
           }}</bkd-preserve-line-height>
-          <a [routerLink]="[test.Id, 'edit']" class="btn btn-link p-0 edit">
-            @if (test.IsOwner && test.IsPublished === false) {
+          @if (test.IsOwner && test.IsPublished === false) {
+            <a [routerLink]="[test.Id, 'edit']" class="btn btn-link p-0 edit">
               <i class="material-icons">edit</i>
-            }
-          </a>
+            </a>
+          }
         </div>
         <bkd-preserve-line-height>
           {{ test | testSummaryShort }}

--- a/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.scss
+++ b/src/app/events/components/tests/tests-table-test-header/tests-table-test-header.component.scss
@@ -18,11 +18,11 @@
   order: -1;
   padding-bottom: $spacer;
 
-  a {
+  button {
     text-decoration: none;
   }
 
-  a:hover {
+  button:hover {
     color: $body-color;
   }
 


### PR DESCRIPTION
Nur Owner sollen den Test-Status updaten können, siehe https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/882#issuecomment-3072545090

Zusätzlich habe ich zwei kleine Refactorings gemacht:
- Beim Edit-Icon war nur das Icon nicht sichtbar, denn Link konnte man trotzdem klicken/fokussieren
- Status-Update-Action zu einem Button gemacht, damit diese mit der Tastatur fokussiert/ausgelöst werden kann