### PR TITLE
Update dateTo/dateFrom in edit absences filter if empty #934

### DIFF
--- a/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.html
+++ b/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.html
@@ -45,14 +45,20 @@
     <label class="form-label">{{
       "edit-absences.header.date-from" | translate
     }}</label>
-    <bkd-date-select [(value)]="filter.dateFrom"></bkd-date-select>
+    <bkd-date-select
+      [value]="filter.dateFrom"
+      (valueChange)="onDateFromChange($event)"
+    ></bkd-date-select>
   </div>
 
   <div class="col-md-6 col-lg-3">
     <label class="form-label">{{
       "edit-absences.header.date-to" | translate
     }}</label>
-    <bkd-date-select [(value)]="filter.dateTo"></bkd-date-select>
+    <bkd-date-select
+      [value]="filter.dateTo"
+      (valueChange)="onDateToChange($event)"
+    ></bkd-date-select>
   </div>
 
   <div class="col-md-6 col-lg-3">

--- a/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.spec.ts
+++ b/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.spec.ts
@@ -34,7 +34,37 @@ describe("EditAbsencesHeaderComponent", () => {
     fixture.detectChanges();
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("onDateFromChange", () => {
+    it("updates dateFrom and dateTo to same value if empty", () => {
+      const date = new Date(2000, 0, 23);
+      component.onDateFromChange(date);
+      expect(component.filter.dateFrom).toEqual(date);
+      expect(component.filter.dateTo).toEqual(date);
+    });
+
+    it("updates dateFrom but not dateTo if not empty", () => {
+      component.filter.dateTo = new Date();
+      const date = new Date(2000, 0, 23);
+      component.onDateFromChange(date);
+      expect(component.filter.dateFrom).toEqual(date);
+      expect(component.filter.dateTo).not.toEqual(date);
+    });
+  });
+
+  describe("onDateToChange", () => {
+    it("updates dateFrom and dateTo to same value if empty", () => {
+      const date = new Date(2000, 0, 23);
+      component.onDateToChange(date);
+      expect(component.filter.dateTo).toEqual(date);
+      expect(component.filter.dateFrom).toEqual(date);
+    });
+
+    it("updates dateFrom but not dateTo if not empty", () => {
+      component.filter.dateFrom = new Date();
+      const date = new Date(2000, 0, 23);
+      component.onDateToChange(date);
+      expect(component.filter.dateTo).toEqual(date);
+      expect(component.filter.dateFrom).not.toEqual(date);
+    });
   });
 });

--- a/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.ts
+++ b/src/app/edit-absences/components/edit-absences-header/edit-absences-header.component.ts
@@ -131,6 +131,20 @@ export class EditAbsencesHeaderComponent {
     },
   };
 
+  onDateFromChange(date: Date | null) {
+    this.filter.dateFrom = date;
+    if (!this.filter.dateTo) {
+      this.filter.dateTo = date;
+    }
+  }
+
+  onDateToChange(date: Date | null) {
+    this.filter.dateTo = date;
+    if (!this.filter.dateFrom) {
+      this.filter.dateFrom = date;
+    }
+  }
+
   show(): void {
     this.filterChange.emit({
       ...this.filter,


### PR DESCRIPTION
Ich habe es jetzt mal auf beide Richtungen implementiert (dateTo updaten wenn dateFrom updated wird und dateTo leer und umgekehrt). Werde es je nach Antwort von Sandro noch anpassen.