### PR TITLE
Refactor dossier grades requests to improve performance #962

### DIFF
--- a/src/app/events/services/test-state.service.ts
+++ b/src/app/events/services/test-state.service.ts
@@ -149,10 +149,12 @@ export class TestStateService {
 
   private gradingScaleIds$ = this.course$.pipe(
     map((course: Course) =>
-      uniq([
-        ...(course.Tests ?? []).map((test: Test) => test.GradingScaleId),
-        course.GradingScaleId,
-      ]).filter(notNull),
+      uniq(
+        [
+          ...(course.Tests ?? []).map((test: Test) => test.GradingScaleId),
+          course.GradingScaleId,
+        ].filter(notNull),
+      ),
     ),
     distinctUntilChanged(isEqual),
     shareReplay(1),

--- a/src/app/shared/services/courses-rest.service.spec.ts
+++ b/src/app/shared/services/courses-rest.service.spec.ts
@@ -118,10 +118,10 @@ describe("CoursesRestService", () => {
         .flush(Course.encode(mockCourse));
     });
 
-    it("should request all courses for Dossier, expanding Tests, Gradings, FinalGrades and EvaluationStatusRef, Classes and ParticipatingStudents", () => {
+    it("should request courses for the given course IDs, expanding Tests, Gradings, FinalGrades and EvaluationStatusRef, Classes and ParticipatingStudents", () => {
       const data: any[] = [];
 
-      service.getExpandedCoursesForDossier().subscribe((result) => {
+      service.getExpandedCoursesForDossier([1, 2, 3]).subscribe((result) => {
         expect(result).toEqual(data);
       });
 
@@ -129,7 +129,7 @@ describe("CoursesRestService", () => {
         .expectOne(
           (req) =>
             req.url ===
-            "https://eventotest.api/Courses/?expand=Tests,Gradings,FinalGrades,EvaluationStatusRef,ParticipatingStudents,Classes&filter.StatusId=;14030;14025;14017;14020;10350;10335;10355;10315;10330;1032510320;10340;10345;10230;10225;10240;10260;10217;10235;10220;10226;10227;10250;10300",
+            "https://eventotest.api/Courses/?expand=Tests,Gradings,FinalGrades,EvaluationStatusRef,ParticipatingStudents,Classes&filter.StatusId=;14030;14025;14017;14020;10350;10335;10355;10315;10330;1032510320;10340;10345;10230;10225;10240;10260;10217;10235;10220;10226;10227;10250;10300&filter.Id=;1;2;3",
         )
         .flush(data);
     });

--- a/src/app/shared/services/courses-rest.service.ts
+++ b/src/app/shared/services/courses-rest.service.ts
@@ -81,10 +81,12 @@ export class CoursesRestService extends RestService<typeof Course> {
       .pipe(switchMap(decode(Course)));
   }
 
-  getExpandedCoursesForDossier(): Observable<ReadonlyArray<Course>> {
+  getExpandedCoursesForDossier(
+    courseIds: ReadonlyArray<number>,
+  ): Observable<ReadonlyArray<Course>> {
     return this.http
       .get<unknown>(
-        `${this.baseUrl}/?expand=Tests,Gradings,FinalGrades,EvaluationStatusRef,ParticipatingStudents,Classes&filter.StatusId=;${this.settings.eventlist["statusfilter"]}`,
+        `${this.baseUrl}/?expand=Tests,Gradings,FinalGrades,EvaluationStatusRef,ParticipatingStudents,Classes&filter.StatusId=;${this.settings.eventlist["statusfilter"]}&filter.Id=;${courseIds.join(";")}`,
       )
       .pipe(switchMap(decodeArray(Course)));
   }

--- a/src/app/shared/services/subscriptions-rest.service.ts
+++ b/src/app/shared/services/subscriptions-rest.service.ts
@@ -54,6 +54,18 @@ export class SubscriptionsRestService extends RestService<typeof Subscription> {
       );
   }
 
+  getSubscriptionsByStudent(
+    personId: number,
+  ): Observable<ReadonlyArray<Subscription>> {
+    return this.http
+      .get<unknown>(`${this.baseUrl}/`, {
+        params: {
+          "filter.PersonId": `=${personId}`,
+        },
+      })
+      .pipe(switchMap(decodeArray(Subscription)));
+  }
+
   getSubscriptionCountsByEvents(
     eventIds: ReadonlyArray<number>,
   ): Observable<Dict<number>> {


### PR DESCRIPTION
Neben der Umstellung der Request-Reihenfolge, habe ich noch das Laden der GradingScales angeglichen an den TestStateService, wo wir es gemäss Kommentar von Max schon refactored hatten.