### PR TITLE
Only consider active subscription in my grades and dossier grades #954

### DIFF
--- a/src/app/dashboard/components/dashboard-timetable/dashboard-timetable.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-timetable/dashboard-timetable.component.spec.ts
@@ -112,6 +112,10 @@ describe("DashboardTimetableComponent", () => {
     element = fixture.debugElement.nativeElement;
   });
 
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   describe("LessonTeacherRole", () => {
     beforeEach(() => {
       dashboardServiceMock.hasLessonTeacherRole$.next(true);

--- a/src/app/presence-control/utils/lesson-entries.spec.ts
+++ b/src/app/presence-control/utils/lesson-entries.spec.ts
@@ -7,6 +7,10 @@ import {
 } from "./lesson-entries";
 
 describe("lessons entries", () => {
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
   describe("getLessonEntriesForLessons", () => {
     it("groups the given lessons as a sorted array of lesson entries", () => {
       const lesson1 = buildLesson(

--- a/src/app/shared/services/apprenticeship-contracts-rest.service.spec.ts
+++ b/src/app/shared/services/apprenticeship-contracts-rest.service.spec.ts
@@ -15,7 +15,10 @@ describe("ApprenticeshipContractsRestService", () => {
     jasmine.clock().mockDate(new Date(Date.UTC(2000, 0, 23, 12, 0)));
   });
 
-  afterEach(() => httpTestingController.verify());
+  afterEach(() => {
+    httpTestingController.verify();
+    jasmine.clock().uninstall();
+  });
 
   describe("getCompaniesForStudents", () => {
     it("requests the companies for the given student ids", () => {

--- a/src/app/shared/services/courses-rest.service.ts
+++ b/src/app/shared/services/courses-rest.service.ts
@@ -91,10 +91,12 @@ export class CoursesRestService extends RestService<typeof Course> {
       .pipe(switchMap(decodeArray(Course)));
   }
 
-  getExpandedCoursesForStudent(): Observable<ReadonlyArray<Course>> {
+  getExpandedCoursesForStudent(
+    courseIds: ReadonlyArray<number>,
+  ): Observable<ReadonlyArray<Course>> {
     return this.http
       .get<unknown>(
-        `${this.baseUrl}/?expand=Tests,Gradings,FinalGrades&filter.StatusId=;${this.settings.eventlist["statusfilter"]}`,
+        `${this.baseUrl}/?expand=Tests,Gradings,FinalGrades&filter.StatusId=;${this.settings.eventlist["statusfilter"]}&filter.Id=;${courseIds.join(";")}`,
         {
           headers: { "X-Role-Restriction": "StudentRole" },
         },

--- a/src/app/shared/services/subscriptions-rest.service.spec.ts
+++ b/src/app/shared/services/subscriptions-rest.service.spec.ts
@@ -15,36 +15,6 @@ describe("SubscriptionsRestService", () => {
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  describe(".getIdSubscriptionsByStudentAndCourse", () => {
-    it("should get list of IdSubscriptions for a students and its courses", () => {
-      const personId = 1;
-      const courseIds = [11, 12, 13];
-      const data: ReadonlyArray<Subscription> = [
-        buildSubscription(1, 11, personId),
-        buildSubscription(2, 12, personId),
-      ];
-
-      const expectedUrl = `https://eventotest.api/Subscriptions/?filter.PersonId==1&filter.EventId=;11,12,13`;
-
-      let result: ReadonlyArray<number> | undefined;
-      service
-        .getSubscriptionIdsByStudentAndCourse(personId, courseIds)
-        .subscribe((response) => {
-          result = response;
-        });
-
-      httpTestingController
-        .expectOne(
-          ({ urlWithParams }) => urlWithParams === expectedUrl,
-          expectedUrl,
-        )
-        .flush(data);
-
-      httpTestingController.verify();
-      expect(result).toEqual(data.map((s) => s.Id));
-    });
-  });
-
   describe(".getSubscriptionsByCourse", () => {
     it("should get list of Subscriptions for a course", () => {
       const courseId = 9704;

--- a/src/app/shared/services/subscriptions-rest.service.ts
+++ b/src/app/shared/services/subscriptions-rest.service.ts
@@ -20,23 +20,6 @@ export class SubscriptionsRestService extends RestService<typeof Subscription> {
     super(http, settings, Subscription, "Subscriptions");
   }
 
-  getSubscriptionIdsByStudentAndCourse(
-    personId: number,
-    eventIds: ReadonlyArray<number>,
-  ): Observable<ReadonlyArray<number>> {
-    return this.http
-      .get<unknown>(`${this.baseUrl}/`, {
-        params: {
-          "filter.PersonId": `=${personId}`,
-          "filter.EventId": `;${eventIds}`,
-        },
-      })
-      .pipe(
-        switchMap(decodeArray(Identifiable)),
-        map((result) => result.map((i) => i.Id)),
-      );
-  }
-
   getSubscriptionIdsByEventAndStudents(
     eventId: number,
     personIds: ReadonlyArray<number>,
@@ -56,11 +39,13 @@ export class SubscriptionsRestService extends RestService<typeof Subscription> {
 
   getSubscriptionsByStudent(
     personId: number,
+    additionalParams?: Dict<string>,
   ): Observable<ReadonlyArray<Subscription>> {
     return this.http
       .get<unknown>(`${this.baseUrl}/`, {
         params: {
           "filter.PersonId": `=${personId}`,
+          ...additionalParams,
         },
       })
       .pipe(switchMap(decodeArray(Subscription)));


### PR DESCRIPTION
- [x] Laden der Kurse umgestellt analog https://github.com/bkd-mba-fbi/webapp-schulverwaltung/pull/976, damit nur noch Kurse angezeigt werden, bei welchen die Schülerin eine Subscription hat.
- [x] Ich habe noch dafür gesorgt, dass die gemockten Timers immer schön zurückgesetzt werden, sonst gibt es flaky Tests...