### PR TITLE
Load only active subscriptions in dossier grades services as well #962

### DIFF
--- a/src/app/my-grades/services/my-grades.service.ts
+++ b/src/app/my-grades/services/my-grades.service.ts
@@ -103,14 +103,12 @@ export class MyGradesService {
     eventIds: ReadonlyArray<number>;
   }> {
     return this.loadingService.load(
-      this.subscriptionRestService
-        .getSubscriptionsByStudent(studentId, { "filter.IsOkay": "=1" })
-        .pipe(
-          map((subscriptions) => ({
-            subscriptionIds: subscriptions.map((s) => s.Id),
-            eventIds: subscriptions.map((s) => s.EventId).filter(notNull),
-          })),
-        ),
+      this.subscriptionRestService.getSubscriptionsByStudent(studentId).pipe(
+        map((subscriptions) => ({
+          subscriptionIds: subscriptions.map((s) => s.Id),
+          eventIds: subscriptions.map((s) => s.EventId).filter(notNull),
+        })),
+      ),
     );
   }
 }

--- a/src/app/shared/services/subscriptions-rest.service.ts
+++ b/src/app/shared/services/subscriptions-rest.service.ts
@@ -39,13 +39,12 @@ export class SubscriptionsRestService extends RestService<typeof Subscription> {
 
   getSubscriptionsByStudent(
     personId: number,
-    additionalParams?: Dict<string>,
   ): Observable<ReadonlyArray<Subscription>> {
     return this.http
       .get<unknown>(`${this.baseUrl}/`, {
         params: {
           "filter.PersonId": `=${personId}`,
-          ...additionalParams,
+          "filter.IsOkay": "=1",
         },
       })
       .pipe(switchMap(decodeArray(Subscription)));


### PR DESCRIPTION
Im Dossier, unter Noten, mussten auch noch die Subscriptions nach `IsOkay==true` gefiltert werden.

Wir hatten das eigentlich explizit nicht mit geändert, also wir es für «Meine Noten» angepasst haben. Aber es ist dort auch nötig gewesen. Habe deshalb es direkt im `getSubscriptionsByStudent` gemacht, welches nur an diesen beiden Orten verwendet wird.