### PR TITLE
Check study courses event leadership via endpoint #1010

### DIFF
--- a/src/app/events/services/study-courses-state.service.spec.ts
+++ b/src/app/events/services/study-courses-state.service.spec.ts
@@ -1,10 +1,11 @@
 import { HttpTestingController } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
 import * as t from "io-ts/lib/index";
+import { EventLeadership } from "src/app/shared/models/event-leadership.model";
 import { Event } from "src/app/shared/models/event.model";
 import { Subscription } from "src/app/shared/models/subscription.model";
 import { StorageService } from "src/app/shared/services/storage.service";
-import { buildSubscription } from "src/spec-builders";
+import { buildEventLeadership, buildSubscription } from "src/spec-builders";
 import { buildTestModuleMetadata } from "src/spec-helpers";
 import { EventEntry } from "./events-state.service";
 import { StudyCoursesStateService } from "./study-courses-state.service";
@@ -16,6 +17,7 @@ describe("StudyCoursesStateService", () => {
   let studyCourses: Event[];
   let studyCoursesEntries: EventEntry[];
   let subscriptions: Subscription[];
+  let leaderships: EventLeadership[];
 
   beforeEach(() => {
     TestBed.configureTestingModule(
@@ -74,6 +76,11 @@ describe("StudyCoursesStateService", () => {
       buildSubscription(100, 10, 2),
       buildSubscription(100, 10, 3),
     ];
+
+    leaderships = [
+      buildEventLeadership(123, 10),
+      buildEventLeadership(123, 11),
+    ];
   });
 
   it("loads events with study courses", () => {
@@ -82,6 +89,7 @@ describe("StudyCoursesStateService", () => {
     });
 
     expectStudyCoursesRequest();
+    expectEventLeadershipsRequest();
     expectSubscriptionsRequest();
 
     httpTestingController.verify();
@@ -100,5 +108,14 @@ describe("StudyCoursesStateService", () => {
     httpTestingController
       .expectOne(url)
       .flush(t.array(Subscription).encode(response));
+  }
+
+  function expectEventLeadershipsRequest(response = leaderships): void {
+    const url =
+      "https://eventotest.api/EventLeaderships/?filter.PersonId==123&filter.EventId=;10;20";
+
+    httpTestingController
+      .expectOne(url)
+      .flush(t.array(EventLeadership).encode(response));
   }
 });

--- a/src/app/events/services/study-courses-state.service.ts
+++ b/src/app/events/services/study-courses-state.service.ts
@@ -10,9 +10,9 @@ import {
   switchMap,
 } from "rxjs";
 import { EventEntry } from "src/app/events/services/events-state.service";
-import { isStudyCourseLeader } from "src/app/events/utils/events";
 import { getEventsStudentsLink } from "src/app/events/utils/events-students";
 import { Event } from "src/app/shared/models/event.model";
+import { EventLeadershipRestService } from "src/app/shared/services/event-leadership-rest.service";
 import { EventsRestService } from "src/app/shared/services/events-rest.service";
 import { LoadingService } from "src/app/shared/services/loading-service";
 import { StorageService } from "src/app/shared/services/storage.service";
@@ -27,6 +27,7 @@ export class StudyCoursesStateService {
   private storageService = inject(StorageService);
   private eventsRestService = inject(EventsRestService);
   private subscriptionsRestService = inject(SubscriptionsRestService);
+  private eventLeadershipService = inject(EventLeadershipRestService);
 
   loading$ = this.loadingService.loading$;
 
@@ -49,15 +50,9 @@ export class StudyCoursesStateService {
   }
 
   private loadStudyCourses(): Observable<ReadonlyArray<EventEntry>> {
-    const tokenPayload = this.storageService.getPayload();
     return this.loadingService.load(
       this.eventsRestService.getStudyCourseEvents().pipe(
-        map((studyCourses) =>
-          // The user sees only the study courses he/she is leader of
-          studyCourses.filter((studyCourse) =>
-            isStudyCourseLeader(tokenPayload, studyCourse),
-          ),
-        ),
+        switchMap(this.filterLeadingStudyCourses.bind(this)), // The user sees only the study courses he/she is leader of
         switchMap(this.decorateWithStudentCounts.bind(this)),
         map(this.createFromStudyCourses.bind(this)),
         map((studyCourses) =>
@@ -70,6 +65,35 @@ export class StudyCoursesStateService {
         stopOnFirstValue: true,
       },
     );
+  }
+
+  private filterLeadingStudyCourses(
+    studyCourses: ReadonlyArray<Event>,
+  ): Observable<ReadonlyArray<Event>> {
+    return this.loadLeadingEventIds(studyCourses).pipe(
+      map((leadingEventIds) =>
+        studyCourses.filter((studyCourse) =>
+          leadingEventIds.includes(studyCourse.Id),
+        ),
+      ),
+    );
+  }
+
+  private loadLeadingEventIds(
+    studyCourses: ReadonlyArray<Event>,
+  ): Observable<ReadonlyArray<number>> {
+    const personId = this.storageService.getPayload()?.id_person;
+    if (!personId) return of([]);
+
+    const eventIds = studyCourses.map((studyCourse) => studyCourse.Id);
+
+    return this.eventLeadershipService
+      .getLeadershipsForPersonAndEvents(Number(personId), eventIds)
+      .pipe(
+        map((leaderships) =>
+          leaderships.map((leadership) => leadership.EventId),
+        ),
+      );
   }
 
   private decorateWithStudentCounts(

--- a/src/app/events/utils/events.spec.ts
+++ b/src/app/events/utils/events.spec.ts
@@ -1,18 +1,7 @@
 import { EvaluationStatusRef } from "src/app/shared/models/course.model";
-import { Event } from "src/app/shared/models/event.model";
-import { TokenPayload } from "src/app/shared/models/token-payload.model";
-import {
-  buildCourse,
-  buildEvent,
-  buildFinalGrading,
-} from "../../../spec-builders";
+import { buildCourse, buildFinalGrading } from "../../../spec-builders";
 import { EventState } from "../services/events-state.service";
-import {
-  canSetFinalGrade,
-  getEventState,
-  isRated,
-  isStudyCourseLeader,
-} from "./events";
+import { canSetFinalGrade, getEventState, isRated } from "./events";
 
 describe("Event/course utility functions", () => {
   describe("getEventState", () => {
@@ -295,58 +284,6 @@ describe("Event/course utility functions", () => {
       course.FinalGrades = null;
 
       expect(isRated(course)).toBeFalse();
-    });
-  });
-
-  describe("isStudyCourseLeader", () => {
-    let event: Event;
-    let tokenPayload: TokenPayload;
-
-    beforeEach(() => {
-      event = buildEvent(1234, "Gymnasialer Bildungsgang");
-      tokenPayload = {
-        culture_info: "de_CH",
-        fullname: "Jane Doe",
-        id_person: "123",
-        holder_id: "456",
-        instance_id: "678",
-        roles: "",
-        substitution_id: undefined,
-      };
-    });
-
-    describe("study course with single leadership", () => {
-      beforeEach(() => {
-        event.Leadership = "Jane Doe";
-      });
-
-      it("returns false if token payload is unavailable", () => {
-        expect(isStudyCourseLeader(null, event)).toBeFalse();
-      });
-
-      it("returns true if user is leader", () => {
-        expect(isStudyCourseLeader(tokenPayload, event)).toBeTrue();
-      });
-
-      it("returns false if user is not leader", () => {
-        tokenPayload.fullname = "Jeanne Doe";
-        expect(isStudyCourseLeader(tokenPayload, event)).toBeFalse();
-      });
-    });
-
-    describe("study course with multiple leaderships", () => {
-      beforeEach(() => {
-        event.Leadership = "John Doe, Jane Doe";
-      });
-
-      it("returns true if user is leader", () => {
-        expect(isStudyCourseLeader(tokenPayload, event)).toBeTrue();
-      });
-
-      it("returns false if user is not leader", () => {
-        tokenPayload.fullname = "Jeanne Doe";
-        expect(isStudyCourseLeader(tokenPayload, event)).toBeFalse();
-      });
     });
   });
 });

--- a/src/app/events/utils/events.ts
+++ b/src/app/events/utils/events.ts
@@ -1,5 +1,3 @@
-import { Event } from "src/app/shared/models/event.model";
-import { TokenPayload } from "src/app/shared/models/token-payload.model";
 import { Course } from "../../shared/models/course.model";
 import { EventState } from "../services/events-state.service";
 
@@ -95,23 +93,4 @@ export function getCourseDesignation(course: Course): string {
     : null;
 
   return classes ? course.Designation + ", " + classes : course.Designation;
-}
-
-/**
- * Returns whether the user with the given token payload is leader of the given
- * study course.
- */
-export function isStudyCourseLeader(
-  tokenPayload: Option<TokenPayload>,
-  studyCourse: Event,
-): boolean {
-  if (!tokenPayload) return false;
-
-  // As a workaround (since the API does not provide the ID of the leadership
-  // and the `/EventLeaderships` are not accessible with the Tutoring token), we
-  // compare the user's fullname with the event's `Leadership` field containing
-  // the names of all leaders for now.
-  return (studyCourse.Leadership ?? "")
-    .split(",")
-    .some((leader) => leader.trim() === tokenPayload.fullname);
 }

--- a/src/app/shared/models/event-leadership.model.ts
+++ b/src/app/shared/models/event-leadership.model.ts
@@ -1,0 +1,13 @@
+import * as t from "io-ts";
+
+const EventLeadership = t.type({
+  Id: t.number,
+  EventId: t.number,
+  PersonId: t.number,
+  // Role: t.string,
+  // RoleId: t.number,
+  // HRef: t.string,
+});
+
+type EventLeadership = t.TypeOf<typeof EventLeadership>;
+export { EventLeadership };

--- a/src/app/shared/services/event-leadership-rest.service.spec.ts
+++ b/src/app/shared/services/event-leadership-rest.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { EventLeadershipRestService } from "./event-leadership-rest.service";
+
+describe("EventLeadershipRestService", () => {
+  let service: EventLeadershipRestService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule(buildTestModuleMetadata({}));
+    service = TestBed.inject(EventLeadershipRestService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/event-leadership-rest.service.ts
+++ b/src/app/shared/services/event-leadership-rest.service.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable, inject } from "@angular/core";
+import { Observable } from "rxjs";
+import { SETTINGS, Settings } from "src/app/settings";
+import { EventLeadership } from "../models/event-leadership.model";
+import { RestService } from "./rest.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class EventLeadershipRestService extends RestService<
+  typeof EventLeadership
+> {
+  constructor() {
+    const http = inject(HttpClient);
+    const settings = inject<Settings>(SETTINGS);
+
+    super(http, settings, EventLeadership, "EventLeaderships");
+  }
+
+  /**
+   * This request only works with 'NG' scope. To test use a token with this
+   * scope.
+   */
+  getLeadershipsForPersonAndEvents(
+    personId: number,
+    eventIds: ReadonlyArray<number>,
+  ): Observable<ReadonlyArray<EventLeadership>> {
+    return super.getList({
+      params: {
+        "filter.PersonId": `=${personId}`,
+        "filter.EventId": `;${eventIds.join(";")}`,
+      },
+    });
+  }
+}

--- a/src/spec-builders.ts
+++ b/src/spec-builders.ts
@@ -13,6 +13,7 @@ import {
   FinalGrading,
   Grading,
 } from "./app/shared/models/course.model";
+import { EventLeadership } from "./app/shared/models/event-leadership.model";
 import { Event } from "./app/shared/models/event.model";
 import { GradingItem } from "./app/shared/models/grading-item.model";
 import { Grade, GradingScale } from "./app/shared/models/grading-scale.model";
@@ -866,5 +867,16 @@ function buildFinalGrade(): FinalGrade {
     gradeId: 20,
     finalGradeValue: "5.5",
     canGrade: true,
+  };
+}
+
+export function buildEventLeadership(
+  personId: number,
+  eventId: number,
+): EventLeadership {
+  return {
+    Id: 1,
+    EventId: eventId,
+    PersonId: personId,
   };
 }


### PR DESCRIPTION
Änderungen:

- `isStudyCourseLeader` Helper entfernt, welcher die Überprüfung via `fullname` gemacht hatte.
- Überprüfung neu via `/EventLeaderships/` Endpunkt.

Zum Testen:

- Mit stg@test.ch unter «Aufnahmeverfahren»
- Token muss für den Scope `NG` sein → habe Token-Script erweitert