### PR TITLE
Add fix for possible race condition after test creation/update #998

### DIFF
--- a/src/app/events/components/tests/tests-add/tests-add.component.ts
+++ b/src/app/events/components/tests/tests-add/tests-add.component.ts
@@ -54,13 +54,13 @@ export class TestsAddComponent {
   }
 
   private onSaveSuccess(): void {
-    // Make sure new test is displayed
-    this.state.reload();
-
-    this.toastService.success(
-      this.translate.instant("tests.form.save-success"),
-    );
-    this.navigateBack();
+    // Make sure new test is reloaded before navigating back
+    this.state.reload().subscribe(() => {
+      this.toastService.success(
+        this.translate.instant("tests.form.save-success"),
+      );
+      this.navigateBack();
+    });
   }
 
   private navigateBack(): void {

--- a/src/app/events/components/tests/tests-edit/tests-edit.component.ts
+++ b/src/app/events/components/tests/tests-edit/tests-edit.component.ts
@@ -93,13 +93,13 @@ export class TestsEditComponent {
   }
 
   private onSaveSuccess(): void {
-    // Make sure updated data is displayed
-    this.state.reload();
-
-    this.toastService.success(
-      this.translate.instant("tests.form.save-success"),
-    );
-    this.navigateBack();
+    // Make sure updated data is reloaded before navigating back
+    this.state.reload().subscribe(() => {
+      this.toastService.success(
+        this.translate.instant("tests.form.save-success"),
+      );
+      this.navigateBack();
+    });
   }
 
   private onDeleteSuccess(deletedTestId: number): void {

--- a/src/app/events/services/test-state.service.ts
+++ b/src/app/events/services/test-state.service.ts
@@ -16,6 +16,7 @@ import {
   distinctUntilChanged,
   filter,
   map,
+  skip,
   switchMap,
   take,
 } from "rxjs/operators";
@@ -208,10 +209,12 @@ export class TestStateService {
     this._courseId$.next(id);
   }
 
-  reload() {
+  reload(): Observable<Course> {
+    const reloaded$ = this.course$.pipe(skip(1), take(1));
     this._courseId$.pipe(take(1)).subscribe((courseId) => {
       this.setCourseId(courseId);
     });
+    return reloaded$;
   }
 
   setFilter(filter: TestsFilter) {


### PR DESCRIPTION
Siehe Kommentar: https://github.com/bkd-mba-fbi/webapp-schulverwaltung/issues/998#issuecomment-4066207287

Dieser Fix wird das Problem IMO nicht lösen. Es macht aber Sinn ihn zwecks Verbesserung der Robustheit zu mergen.

Vor dieser Änderung hätte es zu folgender Race Condition kommen können:

- Nach dem `reload()` im `onSaveSuccess` der Edit-Komponente wurde nicht gewartet, sondern direkt `navigateBack()` ausgeführt.
- Wenn das Neufetchen länger gedauert hätte, wären immer noch die alten Tests angezeigt worden (`shareReplay(1)` auf `course$`).
- Hätte dann der User innerhalb dieser Zeit die Veröffentlichung (`IsPublished`) geändert und wäre erst danach das Fetch vom `reload()` zurückgekommen, hätte man einen falschen `IsPublished` State im Frontend gehabt.
- Dies ist aber sehr unwahrscheinlich und hätte dazu geführt, dass der «In Arbeit» Link gar nicht angezeigt würde (gemäss Fehlerbeschrieb ist er aber disabled).