### PR TITLE
Avoid duplicate photo request in avatar edit dialog #946

### DIFF
--- a/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.spec.ts
+++ b/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.spec.ts
@@ -95,7 +95,9 @@ describe("AvatarEditDialogComponent", () => {
     ).not.toHaveBeenCalled();
     await component.proceed();
     fixture.detectChanges();
-    expect(additionalInformationsServiceMock.uploadPhoto).toHaveBeenCalled();
+    expect(additionalInformationsServiceMock.uploadPhoto).toHaveBeenCalledTimes(
+      1,
+    );
     expect(component.step()).toBe("uploading");
     expect(component.canCancel()).toBe(true);
     expect(component.canProceed()).toBe(false);

--- a/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.ts
+++ b/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.ts
@@ -113,7 +113,7 @@ export class AvatarEditDialogComponent {
     }
   }
 
-  private upload(image: Option<File>): Promise<void> {
+  private async upload(image: Option<File>): Promise<void> {
     this.saving.set(true);
     const upload$ = of(image).pipe(
       switchMap((image) =>
@@ -128,17 +128,15 @@ export class AvatarEditDialogComponent {
         ),
       ),
     );
-    upload$.subscribe({
-      next: () => {
-        this.saving.set(false);
-        this.activeModal.close(true);
-      },
-      error: (error) => {
-        this.saving.set(false);
-        this.error.set(error);
-        console.error(error);
-      },
-    });
-    return firstValueFrom(upload$);
+
+    try {
+      await firstValueFrom(upload$);
+      this.saving.set(false);
+      this.activeModal.close(true);
+    } catch (error) {
+      this.saving.set(false);
+      this.error.set(error);
+      console.error(error);
+    }
   }
 }


### PR DESCRIPTION
Ursache war, dass ich ein `.subscribe()` _und_ ein `firstValueFrom` gemacht hatte. Habe dies angepasst und den Test ergänzt.