### PR TITLE
Create dossier entry

### DIFF
--- a/src/app/edit-absences/edit-absences.routes.ts
+++ b/src/app/edit-absences/edit-absences.routes.ts
@@ -1,8 +1,6 @@
 import { Routes } from "@angular/router";
-import {
-  STUDENT_PAGES,
-  studentRoute,
-} from "../shared/components/student/student-route";
+import { STUDENT_PAGES } from "../shared/components/student/student-pages";
+import { studentRoute } from "../shared/components/student/student-route";
 import { EditAbsencesEditComponent } from "./components/edit-absences-edit/edit-absences-edit.component";
 import { EditAbsencesListComponent } from "./components/edit-absences-list/edit-absences-list.component";
 import { EditAbsencesComponent } from "./components/edit-absences/edit-absences.component";

--- a/src/app/events/components/evaluation/evaluation-grade/evaluation-grade.component.ts
+++ b/src/app/events/components/evaluation/evaluation-grade/evaluation-grade.component.ts
@@ -41,7 +41,7 @@ export class EvaluationGradeComponent implements OnDestroy {
     this.destroy$.complete();
   }
 
-  onValueChange(value: Option<number>): void {
-    this.valueSubject.next(value);
+  onValueChange(value: Option<DropDownItem["Key"]>): void {
+    this.valueSubject.next(value == null ? null : Number(value));
   }
 }

--- a/src/app/events/components/tests/grade-select/grade-select.component.ts
+++ b/src/app/events/components/tests/grade-select/grade-select.component.ts
@@ -21,8 +21,13 @@ export class GradeSelectComponent {
 
   constructor() {}
 
-  onGradeChange(selectedGradeId: Option<number>): void {
-    if (this.gradeId?.valueOf() === undefined) return;
-    this.gradeIdSelected.emit({ id: this.gradeId?.valueOf(), selectedGradeId });
+  onGradeChange(selectedGradeId: Option<DropDownItem["Key"]>): void {
+    if (this.gradeId != null) {
+      this.gradeIdSelected.emit({
+        id: this.gradeId,
+        selectedGradeId:
+          selectedGradeId == null ? null : Number(selectedGradeId),
+      });
+    }
   }
 }

--- a/src/app/events/components/tests/grade/grade.component.ts
+++ b/src/app/events/components/tests/grade/grade.component.ts
@@ -99,8 +99,8 @@ export class GradeComponent implements OnInit, OnDestroy, OnChanges {
     this.gradingScaleDisabledSubject$.next(!(points === null || points === ""));
   }
 
-  onGradeChange(gradeId: Option<number>) {
-    this.gradeSubject$.next(gradeId);
+  onGradeChange(gradeId: Option<DropDownItem["Key"]>) {
+    this.gradeSubject$.next(gradeId == null ? null : Number(gradeId));
   }
 
   isGreaterThanMaxPointsAdjusted(points: string): boolean {

--- a/src/app/events/components/tests/tests-edit-form/tests-edit-form.component.html
+++ b/src/app/events/components/tests/tests-edit-form/tests-edit-form.component.html
@@ -210,7 +210,7 @@
         </div>
       }
     </div>
-    <div class="d-flex justify-content-end mt-4">
+    <div class="d-flex justify-content-end gap-2 mt-4">
       <button
         type="button"
         class="btn btn-outline-secondary"
@@ -219,17 +219,9 @@
       >
         {{ "tests.form.cancel" | translate }}
       </button>
-      <button type="submit" class="btn btn-primary ms-2" [disabled]="saving">
+      <bkd-submit-button [saving]="saving">
         {{ "tests.form.save" | translate }}
-        @if (saving) {
-          <div
-            class="spinner-border spinner-border-sm align-middle"
-            role="status"
-          >
-            <span class="visually-hidden">Loading...</span>
-          </div>
-        }
-      </button>
+      </bkd-submit-button>
     </div>
   </form>
 }

--- a/src/app/events/components/tests/tests-edit-form/tests-edit-form.component.ts
+++ b/src/app/events/components/tests/tests-edit-form/tests-edit-form.component.ts
@@ -26,6 +26,7 @@ import {
 import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { uniqueId } from "lodash-es";
 import { BehaviorSubject, Subject, of, takeUntil } from "rxjs";
+import { SubmitButtonComponent } from "src/app/shared/components/submit-button/submit-button.component";
 import { Test } from "src/app/shared/models/test.model";
 import { DateParserFormatter } from "src/app/shared/services/date-parser-formatter";
 import {
@@ -47,6 +48,7 @@ import { TestStateService } from "../../../services/test-state.service";
     RouterLink,
     AsyncPipe,
     TranslatePipe,
+    SubmitButtonComponent,
   ],
   providers: [
     { provide: NgbDateAdapter, useClass: NgbDateNativeAdapter },

--- a/src/app/import/components/common/import-file/import-file.component.html
+++ b/src/app/import/components/common/import-file/import-file.component.html
@@ -6,15 +6,15 @@
   <div class="mb-3">
     <bkd-button-group
       [options]="importTypeOptions"
-      [(selected)]="stateService.importType"
+      [(value)]="stateService.importType"
     ></bkd-button-group>
   </div>
 
   <div class="mb-3">
     <bkd-file-input
-      [acceptedExtensions]="['.xlsx', '.xls', '.csv']"
+      [acceptedFileTypes]="['.xlsx', '.xls', '.csv']"
       [error]="errorMessage()"
-      [(file)]="stateService.file"
+      [(value)]="stateService.file"
     ></bkd-file-input>
   </div>
 

--- a/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.html
+++ b/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.html
@@ -76,7 +76,7 @@
           "my-profile.edit.fields.email2-hint" | translate
         }}</small>
       </div>
-      <div class="d-flex justify-content-end">
+      <div class="d-flex justify-content-end gap-2">
         <button
           type="button"
           class="btn btn-outline-secondary"
@@ -85,21 +85,9 @@
         >
           {{ "my-profile.edit.cancel" | translate }}
         </button>
-        <button
-          type="submit"
-          class="btn btn-primary ms-2"
-          [disabled]="saving$ | async"
-        >
+        <bkd-submit-button [saving]="saving$ | async">
           {{ "my-profile.edit.save" | translate }}
-          @if (saving$ | async) {
-            <div
-              class="spinner-border spinner-border-sm align-middle"
-              role="status"
-            >
-              <span class="visually-hidden">Loading...</span>
-            </div>
-          }
-        </button>
+        </bkd-submit-button>
       </div>
     </form>
   }

--- a/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.ts
+++ b/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.ts
@@ -17,6 +17,7 @@ import { Router } from "@angular/router";
 import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { BehaviorSubject } from "rxjs";
 import { filter, finalize } from "rxjs/operators";
+import { SubmitButtonComponent } from "src/app/shared/components/submit-button/submit-button.component";
 import { Person } from "src/app/shared/models/person.model";
 import { PersonsRestService } from "src/app/shared/services/persons-rest.service";
 import { getValidationErrors } from "src/app/shared/utils/form";
@@ -29,7 +30,13 @@ import { MyProfileService } from "../../services/my-profile.service";
   templateUrl: "./my-profile-edit.component.html",
   styleUrls: ["./my-profile-edit.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, ReactiveFormsModule, AsyncPipe, TranslatePipe],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    AsyncPipe,
+    TranslatePipe,
+    SubmitButtonComponent,
+  ],
 })
 export class MyProfileEditComponent {
   private fb = inject(UntypedFormBuilder);

--- a/src/app/presence-control/presence-control.routes.ts
+++ b/src/app/presence-control/presence-control.routes.ts
@@ -1,8 +1,6 @@
 import { Routes } from "@angular/router";
-import {
-  STUDENT_PAGES,
-  studentRoute,
-} from "../shared/components/student/student-route";
+import { STUDENT_PAGES } from "../shared/components/student/student-pages";
+import { studentRoute } from "../shared/components/student/student-route";
 import { PresenceControlGroupComponent } from "./components/presence-control-group/presence-control-group.component";
 import { PresenceControlListComponent } from "./components/presence-control-list/presence-control-list.component";
 import { PresenceControlComponent } from "./components/presence-control/presence-control.component";

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -62,9 +62,13 @@ const Settings = t.type({
   eventlist: t.record(t.string, t.string),
   dashboard: Dashboard,
   preventStudentAbsenceAfterLessonStart: t.array(t.string),
+  dossierCreateTypeId: t.number,
   dossierEntryEmailTypeId: t.number,
+  dossierCategoriesTypeId: t.number,
   dossierImportantInformationCodeId: t.number,
   dossierDisadvantageCompensationCodeId: t.number,
+  dossierAllowedFileTypes: t.array(t.string),
+  dossierMaxFileSize: t.number,
 });
 
 type Settings = t.TypeOf<typeof Settings>;

--- a/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.html
+++ b/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.html
@@ -12,9 +12,9 @@
             ? ("shared.avatar-edit.dialog.invalid-file" | translate)
             : null;
         <bkd-file-input
-          [acceptedExtensions]="acceptedExtensions"
+          [acceptedFileTypes]="acceptedFileTypes"
           [error]="invalidFileError"
-          [(file)]="file"
+          [(value)]="file"
         ></bkd-file-input>
         <div
           class="alert alert-warning mt-3 d-flex align-items-center"

--- a/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.spec.ts
+++ b/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.spec.ts
@@ -47,10 +47,10 @@ describe("AvatarEditDialogComponent", () => {
                 additionalInformationsServiceMock =
                   jasmine.createSpyObj<AdditionalInformationsRestService>(
                     "AdditionalInformationsRestService",
-                    ["uploadPhoto"],
+                    ["createAvatar"],
                   );
 
-                additionalInformationsServiceMock.uploadPhoto.and.returnValue(
+                additionalInformationsServiceMock.createAvatar.and.returnValue(
                   of(undefined),
                 );
 
@@ -91,13 +91,13 @@ describe("AvatarEditDialogComponent", () => {
 
     // Proceed to "uploading" step
     expect(
-      additionalInformationsServiceMock.uploadPhoto,
+      additionalInformationsServiceMock.createAvatar,
     ).not.toHaveBeenCalled();
     await component.proceed();
     fixture.detectChanges();
-    expect(additionalInformationsServiceMock.uploadPhoto).toHaveBeenCalledTimes(
-      1,
-    );
+    expect(
+      additionalInformationsServiceMock.createAvatar,
+    ).toHaveBeenCalledTimes(1);
     expect(component.step()).toBe("uploading");
     expect(component.canCancel()).toBe(true);
     expect(component.canProceed()).toBe(false);

--- a/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.ts
+++ b/src/app/shared/components/avatar-edit-dialog/avatar-edit-dialog.component.ts
@@ -38,7 +38,7 @@ export class AvatarEditDialogComponent {
 
   step = signal<AvatarEditDialogStep>("choose");
 
-  acceptedExtensions = [".jpg", ".jpeg", ".png"];
+  acceptedFileTypes = [".jpg", ".jpeg", ".png"];
   acceptedMimeTypes = ["image/jpeg", "image/png"];
   file = signal<Option<File>>(null);
   invalidFile = computed(
@@ -122,7 +122,7 @@ export class AvatarEditDialogComponent {
           : throwError(() => new Error("No avatar image available")),
       ),
       switchMap((image) =>
-        this.additionalInformationsRestService.uploadPhoto(
+        this.additionalInformationsRestService.createAvatar(
           this.studentId(),
           image,
         ),

--- a/src/app/shared/components/button-group/button-group.component.html
+++ b/src/app/shared/components/button-group/button-group.component.html
@@ -1,13 +1,13 @@
 <div class="button-group" role="group">
   @for (option of options(); track option.key) {
     <button
-      (click)="selected.set(option.key)"
+      (click)="value.set(option.key)"
       type="button"
       class="btn btn-primary"
       [ngClass]="{
-        'btn-primary': option.key === selected(),
-        'btn-outline-primary': option.key !== selected(),
-        active: option.key === selected(),
+        'btn-primary': option.key === value(),
+        'btn-outline-primary': option.key !== value(),
+        active: option.key === value(),
       }"
     >
       {{ option.label }}

--- a/src/app/shared/components/button-group/button-group.component.spec.ts
+++ b/src/app/shared/components/button-group/button-group.component.spec.ts
@@ -36,7 +36,7 @@ describe("ButtonGroupComponent", () => {
   });
 
   it("adds class 'active' to the selected option", () => {
-    fixture.componentRef.setInput("selected", options[1].key);
+    fixture.componentRef.setInput("value", options[1].key);
     fixture.detectChanges();
     const buttons = fixture.debugElement.queryAll(By.css("button"));
     expect(buttons[0].nativeElement.classList).not.toContain("active");
@@ -47,6 +47,6 @@ describe("ButtonGroupComponent", () => {
   it("emits option when button is clicked", () => {
     const buttons = fixture.debugElement.queryAll(By.css("button"));
     buttons[1].nativeElement.click();
-    expect(component.selected()).toBe(options[1].key);
+    expect(component.value()).toBe(options[1].key);
   });
 });

--- a/src/app/shared/components/button-group/button-group.component.ts
+++ b/src/app/shared/components/button-group/button-group.component.ts
@@ -20,5 +20,5 @@ export type ButtonGroupOption<TKey extends string = string> = {
 })
 export class ButtonGroupComponent {
   options = input.required<ReadonlyArray<ButtonGroupOption>>();
-  selected = model<Option<ButtonGroupOption["key"]>>(null);
+  value = model<Option<ButtonGroupOption["key"]>>(null);
 }

--- a/src/app/shared/components/file-input/file-input.component.html
+++ b/src/app/shared/components/file-input/file-input.component.html
@@ -3,13 +3,13 @@
 }}</label>
 <input
   class="form-control"
-  [class.is-valid]="file() && !error()"
+  [class.is-valid]="value() && !error()"
   [class.is-invalid]="error()"
   type="file"
   #fileInput
   id="formFile"
   (change)="onFileInput(fileInput.files)"
-  [accept]="acceptedExtensions().join(',')"
+  [accept]="acceptedFileTypes().join(',')"
 />
 @if (error()) {
   <div class="invalid-feedback">{{ error() }}</div>

--- a/src/app/shared/components/file-input/file-input.component.spec.ts
+++ b/src/app/shared/components/file-input/file-input.component.spec.ts
@@ -15,7 +15,7 @@ describe("FileInputComponent", () => {
 
     fixture = TestBed.createComponent(FileInputComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput("acceptedExtensions", [
+    fixture.componentRef.setInput("acceptedFileTypes", [
       ".jpg",
       ".jpeg",
       ".png",

--- a/src/app/shared/components/file-input/file-input.component.ts
+++ b/src/app/shared/components/file-input/file-input.component.ts
@@ -20,11 +20,11 @@ import { TranslatePipe } from "@ngx-translate/core";
 })
 export class FileInputComponent implements AfterViewInit, OnDestroy {
   /**
-   * Example: [".xls", ".xlsx", ".csv"]
+   * Example: [".xls", ".xlsx", ".csv", "image/png"]
    */
-  acceptedExtensions = input.required<ReadonlyArray<string>>();
+  acceptedFileTypes = input.required<ReadonlyArray<string>>();
   error = input<Option<string>>(null);
-  file = model<Option<File>>(null);
+  value = model<Option<File>>(null);
 
   dragging = signal(false); // Used to show the drop zone when dragging a file into the viewport
   private dragCount = 0;
@@ -43,7 +43,7 @@ export class FileInputComponent implements AfterViewInit, OnDestroy {
   }
 
   onFileInput(files: FileList | null): void {
-    this.file.set(files?.item(0) ?? null);
+    this.value.set(files?.item(0) ?? null);
   }
 
   onDragEnter = () => {

--- a/src/app/shared/components/form-errors/form-errors.component.html
+++ b/src/app/shared/components/form-errors/form-errors.component.html
@@ -1,0 +1,7 @@
+@if (submitted()) {
+  @for (error of field().errors(); track error) {
+    <div class="invalid-feedback d-block">
+      {{ "global.validation-errors." + error.kind | translate }}
+    </div>
+  }
+}

--- a/src/app/shared/components/form-errors/form-errors.component.spec.ts
+++ b/src/app/shared/components/form-errors/form-errors.component.spec.ts
@@ -1,0 +1,85 @@
+import { signal } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FieldTree, form, required } from "@angular/forms/signals";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { FormErrorsComponent } from "./form-errors.component";
+
+type Model = {
+  name: string;
+};
+
+describe("FormErrorsComponent", () => {
+  let fixture: ComponentFixture<FormErrorsComponent<string>>;
+  let element: HTMLElement;
+  let testForm: FieldTree<Model, string | number>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [FormErrorsComponent],
+      }),
+    ).compileComponents();
+
+    fixture = TestBed.createComponent(FormErrorsComponent<string>);
+    element = fixture.debugElement.nativeElement;
+
+    testForm = TestBed.runInInjectionContext(() => {
+      const model = signal<Model>({
+        name: "Jane",
+      });
+      return form(model, (schema) => {
+        required(schema.name);
+      });
+    });
+
+    fixture.componentRef.setInput("field", testForm.name());
+    fixture.componentRef.setInput("submitted", true);
+  });
+
+  describe("not yet submitted", () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput("submitted", false);
+    });
+
+    it("does not render an error if valid", () => {
+      testForm.name().value.set("Jane");
+      fixture.detectChanges();
+
+      const errors = element.querySelectorAll(".invalid-feedback");
+      expect(errors.length).toBe(0);
+    });
+
+    it("does not render an error if invalid", () => {
+      testForm.name().value.set("");
+      fixture.detectChanges();
+
+      const errors = element.querySelectorAll(".invalid-feedback");
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe("submitted", () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput("submitted", true);
+    });
+
+    it("does not render an error if valid", () => {
+      testForm.name().value.set("Jane");
+      fixture.detectChanges();
+
+      const errors = element.querySelectorAll(".invalid-feedback");
+      expect(errors.length).toBe(0);
+    });
+
+    it("renders error if invalid", () => {
+      testForm.name().value.set("");
+      fixture.detectChanges();
+
+      const errors = element.querySelectorAll(".invalid-feedback");
+      expect(errors.length).toBe(1);
+      expect(errors[0]?.textContent?.trim()).toBe(
+        "global.validation-errors.required",
+      );
+    });
+  });
+});

--- a/src/app/shared/components/form-errors/form-errors.component.ts
+++ b/src/app/shared/components/form-errors/form-errors.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { FieldState } from "@angular/forms/signals";
+import { TranslatePipe } from "@ngx-translate/core";
+
+@Component({
+  selector: "bkd-form-errors",
+  imports: [TranslatePipe],
+  templateUrl: "./form-errors.component.html",
+  styleUrl: "./form-errors.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormErrorsComponent<
+  TValue,
+  TKey extends string | number = string | number,
+> {
+  field = input.required<FieldState<TValue, TKey>>();
+  submitted = input.required<boolean>();
+}

--- a/src/app/shared/components/select/select.component.html
+++ b/src/app/shared/components/select/select.component.html
@@ -1,17 +1,19 @@
 <select
+  [id]="id()"
   class="form-select"
-  tabindex="{{ tabindex }}"
-  [ngStyle]="{ width }"
-  [disabled]="disabled"
-  [ngModel]="value$ | async"
-  (ngModelChange)="valueChange.emit($event && $event.Key)"
+  [class.is-invalid]="isInvalid()"
+  tabindex="{{ tabindex() }}"
+  [ngStyle]="{ width: width() }"
+  [disabled]="disabled()"
+  [ngModel]="selectedOption()"
+  (ngModelChange)="value.set($event && $event.Key)"
 >
-  @if (allowEmpty) {
+  @if (allowEmpty()) {
     <option [ngValue]="null">
-      {{ emptyLabel | translate }}
+      {{ emptyLabel() | translate }}
     </option>
   }
-  @for (option of options; track option.Key) {
+  @for (option of options(); track option.Key) {
     <option [ngValue]="option">
       {{ option.Value }}
     </option>

--- a/src/app/shared/components/select/select.component.spec.ts
+++ b/src/app/shared/components/select/select.component.spec.ts
@@ -3,9 +3,8 @@ import { buildTestModuleMetadata } from "src/spec-helpers";
 import { SelectComponent } from "./select.component";
 
 describe("SelectComponent", () => {
-  let component: SelectComponent;
   let fixture: ComponentFixture<SelectComponent>;
-  // let element: HTMLElement;
+  let element: HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule(
@@ -15,35 +14,58 @@ describe("SelectComponent", () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SelectComponent);
-    // element = fixture.debugElement.nativeElement;
-    component = fixture.componentInstance;
+    element = fixture.debugElement.nativeElement;
+    fixture.componentRef.setInput("options", [
+      { Key: "apple", Value: "Apple" },
+      { Key: "pear", Value: "Pear" },
+    ]);
+    fixture.componentRef.setInput("value", "pear");
     fixture.detectChanges();
   });
 
-  it("should create default select component", () => {
-    // then
-    expect(component).toBeTruthy();
-    expect(component.allowEmpty).toBeTruthy();
-    expect(component.emptyLabel).toBe("");
-    expect(component.options).toEqual([]);
-    expect(component.value).toBeNull();
+  it("renders the given options including an empty option", () => {
+    const options = Array.from(element.querySelectorAll("option"));
+    expect(options.map((o) => o.textContent?.trim())).toEqual([
+      "",
+      "Apple",
+      "Pear",
+    ]);
   });
 
-  it("should create select component without element", () => {
-    // given
-    component.allowEmpty = false;
-
-    // then
-    expect(component.allowEmpty).toBeFalsy();
+  it("does not render an empty option with allowEmpty=false", () => {
+    fixture.componentRef.setInput("allowEmpty", false);
+    fixture.detectChanges();
+    const options = Array.from(element.querySelectorAll("option"));
+    expect(options.map((o) => o.textContent?.trim())).toEqual([
+      "Apple",
+      "Pear",
+    ]);
   });
 
-  it("should create select component with custom empty element", () => {
-    // given
-    component.allowEmpty = true;
-    component.emptyLabel = "Choose option...";
+  it("uses a custom label for the empty option", () => {
+    fixture.componentRef.setInput("emptyLabel", "None");
+    fixture.detectChanges();
+    const options = Array.from(element.querySelectorAll("option"));
+    expect(options.map((o) => o.textContent?.trim())).toEqual([
+      "None",
+      "Apple",
+      "Pear",
+    ]);
+  });
 
-    // then
-    expect(component.emptyLabel).toBe("Choose option...");
-    expect(component.allowEmpty).toBeTruthy();
+  it("selects the option matching the given value", async () => {
+    await fixture.whenStable();
+
+    const options = Array.from(element.querySelectorAll("option"));
+    expect(options[0].selected).toBeFalse();
+    expect(options[1].selected).toBeFalse();
+    expect(options[2].selected).toBeTrue();
+  });
+
+  it("emits the selected value when changed", () => {
+    const select = element.querySelector("select")!;
+    select.selectedIndex = 1;
+    select.dispatchEvent(new Event("change"));
+    expect(fixture.componentInstance.value()).toBe("apple");
   });
 });

--- a/src/app/shared/components/select/select.component.ts
+++ b/src/app/shared/components/select/select.component.ts
@@ -1,17 +1,13 @@
-import { AsyncPipe, NgStyle } from "@angular/common";
+import { NgStyle } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
+  computed,
+  input,
+  model,
 } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { TranslatePipe } from "@ngx-translate/core";
-import { BehaviorSubject, combineLatest } from "rxjs";
-import { map } from "rxjs/operators";
 import { DropDownItem } from "../../models/drop-down-item.model";
 
 @Component({
@@ -19,37 +15,29 @@ import { DropDownItem } from "../../models/drop-down-item.model";
   templateUrl: "./select.component.html",
   styleUrls: ["./select.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, AsyncPipe, NgStyle, TranslatePipe],
+  imports: [FormsModule, NgStyle, TranslatePipe],
 })
-export class SelectComponent implements OnChanges {
-  @Input() options: ReadonlyArray<DropDownItem> = [];
-  @Input() allowEmpty = true;
-  @Input() emptyLabel: string = "";
-  @Input() value: Option<number> = null;
-  @Input() disabled: boolean = false;
-  @Input() tabindex: number = 0;
-  @Input() width: string = "auto";
+export class SelectComponent<
+  TKey extends DropDownItem["Key"] = DropDownItem["Key"],
+  TValue extends DropDownItem["Value"] = DropDownItem["Value"],
+> {
+  id = input<string>();
+  options = input.required<ReadonlyArray<{ Key: TKey; Value: TValue }>>();
+  allowEmpty = input(true);
+  emptyLabel = input("");
+  disabled = input(false);
+  isInvalid = input(false);
+  tabindex = input(0);
+  width = input("auto");
 
-  @Output() valueChange = new EventEmitter<Option<number>>();
+  value = model<Option<TKey>>(null);
 
-  options$ = new BehaviorSubject<ReadonlyArray<DropDownItem>>([]);
-  rawValue$ = new BehaviorSubject<Option<number>>(null);
-
-  value$ = combineLatest([this.rawValue$, this.options$]).pipe(
-    map(
-      ([rawValue, options]) =>
-        (options && options.find((o) => o.Key === rawValue)) || null,
-    ),
-  );
-
-  constructor() {}
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes["value"]) {
-      this.rawValue$.next(changes["value"].currentValue);
-    }
-    if (changes["options"]) {
-      this.options$.next(changes["options"].currentValue);
-    }
-  }
+  selectedOption = computed(() => {
+    const options = this.options();
+    const rawValue = this.value();
+    return (
+      (options && options.find((o) => String(o.Key) === String(rawValue))) ||
+      null
+    );
+  });
 }

--- a/src/app/shared/components/student/student-dossier-actions/student-dossier-actions.component.html
+++ b/src/app/shared/components/student/student-dossier-actions/student-dossier-actions.component.html
@@ -1,6 +1,9 @@
 <div class="d-flex align-items-center gap-2">
   @if (!readonly()) {
-    <a [routerLink]="['edit', 'new']" class="btn btn-primary btn-icon">
+    <a
+      [routerLink]="['dossier', 'edit', 'new']"
+      class="btn btn-primary btn-icon"
+    >
       <i class="material-icons">add</i>
     </a>
   }

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
@@ -1,0 +1,165 @@
+@let info = additionalInformation();
+
+<bkd-backlink [routerLink]="['../..']"></bkd-backlink>
+
+<div class="bkd-container bkd-container-limited">
+  @if (loading()) {
+    <bkd-spinner></bkd-spinner>
+  } @else if (additionalInformationId() && !info) {
+    <h1>{{ "student.dossier.edit.not-found" | translate }}</h1>
+  } @else {
+    <h1>{{ heading() }}</h1>
+
+    <form (submit)="onSubmit($event)" novalidate>
+      <div class="mb-3">
+        <bkd-button-group
+          [class.is-invalid]="submitted() && entryForm.type().invalid()"
+          [options]="types"
+          [formField]="entryForm.type"
+        ></bkd-button-group>
+        <bkd-form-errors
+          [field]="entryForm.type()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      @if (entryForm.type().value() === "document") {
+        <div class="mb-3">
+          <bkd-file-input
+            [acceptedFileTypes]="acceptedFileTypes"
+            [formField]="entryForm.file"
+            [error]="
+              submitted() && entryForm.file().invalid()
+                ? ('global.validation-errors.' +
+                    entryForm.file().errors()[0].kind
+                  | translate: entryForm.file().errors()[0])
+                : null
+            "
+          ></bkd-file-input>
+        </div>
+      }
+
+      <div class="mb-3">
+        <label for="additional-information-designation" class="form-label">
+          {{ "student.dossier.edit.designation" | translate }}
+        </label>
+        <input
+          type="text"
+          class="form-control"
+          [class.is-invalid]="submitted() && entryForm.designation().invalid()"
+          id="additional-information-designation"
+          [formField]="entryForm.designation"
+        />
+        <bkd-form-errors
+          [field]="entryForm.designation()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      <div class="mb-3">
+        <label for="additional-information-description" class="form-label">
+          {{ "student.dossier.edit.description" | translate }} ({{
+            "student.dossier.edit.optional" | translate
+          }})
+        </label>
+        <textarea
+          class="form-control"
+          id="additional-information-description"
+          [class.is-invalid]="submitted() && entryForm.description().invalid()"
+          [formField]="entryForm.description"
+        ></textarea>
+        <bkd-form-errors
+          [field]="entryForm.description()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      <div class="mb-3">
+        <label for="additional-information-category" class="form-label">
+          {{ "student.dossier.edit.category" | translate }}
+        </label>
+        <bkd-select
+          id="additional-information-category"
+          [allowEmpty]="false"
+          [isInvalid]="submitted() && entryForm.category().invalid()"
+          [options]="categories()"
+          [formField]="entryForm.category"
+        ></bkd-select>
+        <bkd-form-errors
+          [field]="entryForm.category()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      <div>
+        <label for="additional-information-for-teacher" class="form-label">
+          {{ "student.dossier.edit.visibility" | translate }}
+        </label>
+        <div>
+          @for (option of ["class-teacher-only", "all"]; track option) {
+            <div class="form-check form-check-inline">
+              <input
+                class="form-check-input"
+                type="radio"
+                [id]="'additional-information-for-teacher-' + option"
+                [class.is-invalid]="
+                  submitted() && entryForm.forTeacher().invalid()
+                "
+                [formField]="entryForm.forTeacher"
+                [value]="option"
+              />
+              <label
+                class="form-check-label"
+                [attr.for]="'additional-information-for-teacher-' + option"
+              >
+                {{ "student.dossier.edit.for-teacher-" + option | translate }}
+              </label>
+            </div>
+          }
+        </div>
+        <bkd-form-errors
+          [field]="entryForm.forStudent()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      <div class="mb-3">
+        <div>
+          <div class="form-check">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="additional-information-for-student"
+              [class.is-invalid]="
+                submitted() && entryForm.forStudent().invalid()
+              "
+              [formField]="entryForm.forStudent"
+            />
+            <label
+              class="form-check-label"
+              [attr.for]="'additional-information-for-student'"
+            >
+              {{
+                "student.dossier.edit.for-student"
+                  | translate: { studentName: studentName() ?? "?" }
+              }}
+            </label>
+          </div>
+        </div>
+        <bkd-form-errors
+          [field]="entryForm.forStudent()"
+          [submitted]="submitted()"
+        ></bkd-form-errors>
+      </div>
+
+      <div class="d-flex justify-content-end gap-2">
+        <a class="btn btn-outline-secondary" [routerLink]="['../..']">
+          {{ "student.dossier.edit.cancel" | translate }}
+        </a>
+        <bkd-submit-button [saving]="saving()">
+          {{ "student.dossier.edit.save" | translate }}
+        </bkd-submit-button>
+      </div>
+    </form>
+  }
+</div>

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
@@ -1,0 +1,233 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { BehaviorSubject, of } from "rxjs";
+import { AdditionalInformation } from "src/app/shared/models/additional-informations.model";
+import { StudentDossierEditService } from "src/app/shared/services/student-dossier-edit.service";
+import { ToastService } from "src/app/shared/services/toast.service";
+import { buildAdditionalInformation } from "src/spec-builders";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { StudentDossierEditComponent } from "./student-dossier-edit.component";
+
+describe("StudentDossierEditComponent", () => {
+  let component: StudentDossierEditComponent;
+  let fixture: ComponentFixture<StudentDossierEditComponent>;
+  let editService: jasmine.SpyObj<StudentDossierEditService>;
+  let toastService: jasmine.SpyObj<ToastService>;
+  let router: jasmine.SpyObj<Router>;
+  let additionalInformationId$: BehaviorSubject<Option<number>>;
+  let additionalInformation$: BehaviorSubject<Option<AdditionalInformation>>;
+
+  beforeEach(async () => {
+    additionalInformationId$ = new BehaviorSubject<Option<number>>(null);
+    additionalInformation$ = new BehaviorSubject<Option<AdditionalInformation>>(
+      null,
+    );
+    editService = jasmine.createSpyObj(
+      "StudentDossierEditService",
+      ["getSubscriptionId", "save"],
+      {
+        loading$: of(false),
+        studentId$: of(42),
+        studentName$: of("Mustermann Max"),
+        additionalInformationId$,
+        additionalInformation$,
+        categories$: of([
+          {
+            Key: 2000267,
+            Value: "Administration",
+            IsActive: true,
+            Sort: "1011",
+          },
+          {
+            Key: 2000268,
+            Value: "Ärztliches Attest",
+            IsActive: true,
+            Sort: "1011",
+          },
+        ]),
+      },
+    );
+    editService.getSubscriptionId.and.returnValue(Promise.resolve(10));
+    editService.save.and.returnValue(Promise.resolve());
+
+    toastService = jasmine.createSpyObj("ToastService", ["success"]);
+    router = jasmine.createSpyObj("Router", ["navigate"]);
+
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [StudentDossierEditComponent],
+        providers: [
+          { provide: ToastService, useValue: toastService },
+          { provide: Router, useValue: router },
+          { provide: ActivatedRoute, useValue: {} },
+        ],
+      }),
+    )
+      .overrideComponent(StudentDossierEditComponent, {
+        set: {
+          providers: [
+            { provide: StudentDossierEditService, useValue: editService },
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(StudentDossierEditComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe("create new entry", () => {
+    beforeEach(() => {
+      additionalInformationId$.next(null);
+      additionalInformation$.next(null);
+      fixture.detectChanges();
+    });
+
+    describe("heading", () => {
+      it("returns the heading for a new entry", () => {
+        expect(component.heading()).toBe("student.dossier.edit.title-new");
+      });
+    });
+
+    describe("onSubmit", () => {
+      it("does nothing if form is invalid", async () => {
+        await component.onSubmit(new Event("submit"));
+        expect(editService.save).not.toHaveBeenCalled();
+        expect(toastService.success).not.toHaveBeenCalled();
+      });
+
+      describe("note", () => {
+        it("saves the entry for class teacher only", async () => {
+          component.entryForm.type().value.set("note");
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "note",
+            {
+              ObjectId: 10,
+              ObjectTypeId: 2,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: null,
+              ForStudent: true,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+
+        it("saves the entry for all teachers", async () => {
+          component.entryForm.type().value.set("note");
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          component.entryForm.forTeacher().value.set("all");
+          component.entryForm.forStudent().value.set(false);
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "note",
+            {
+              ObjectId: 42,
+              ObjectTypeId: 3,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: null,
+              ForStudent: false,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+      });
+
+      describe("document", () => {
+        it("saves the entry for class teacher only", async () => {
+          const file = new File([""], "test.pdf", { type: "application/pdf" });
+          component.entryForm.type().value.set("document");
+          component.entryForm.file().value.set(file);
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "document",
+            {
+              ObjectId: 10,
+              ObjectTypeId: 2,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: null,
+              ForStudent: true,
+            },
+            file,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+
+        it("saves the entry for all teachers", async () => {
+          const file = new File([""], "test.pdf", { type: "application/pdf" });
+          component.entryForm.type().value.set("document");
+          component.entryForm.file().value.set(file);
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          component.entryForm.forTeacher().value.set("all");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "document",
+            {
+              ObjectId: 42,
+              ObjectTypeId: 3,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: null,
+              ForStudent: true,
+            },
+            file,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("edit existing entry", () => {
+    let additionalInformation: AdditionalInformation;
+    beforeEach(async () => {
+      additionalInformation = buildAdditionalInformation();
+      additionalInformationId$.next(additionalInformation.Id);
+      additionalInformation$.next(additionalInformation);
+      fixture.detectChanges();
+      await fixture.whenStable();
+    });
+
+    describe("heading", () => {
+      it("returns the heading for an existing entry", () => {
+        expect(component.heading()).toBe("student.dossier.edit.title-update");
+      });
+    });
+
+    describe("onSubmit", () => {
+      it("does nothing if form is invalid", async () => {
+        component.entryForm.designation().value.set("");
+        fixture.detectChanges();
+
+        await component.onSubmit(new Event("submit"));
+        expect(editService.save).not.toHaveBeenCalled();
+        expect(toastService.success).not.toHaveBeenCalled();
+      });
+
+      // TODO: Add update tests in #929
+    });
+  });
+});

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
@@ -1,0 +1,225 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { FormField, form, required } from "@angular/forms/signals";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { TranslatePipe, TranslateService } from "@ngx-translate/core";
+import { SETTINGS, Settings } from "src/app/settings";
+import { AdditionalInformation } from "src/app/shared/models/additional-informations.model";
+import { DropDownItem } from "src/app/shared/models/drop-down-item.model";
+import { StudentDossierEditService } from "src/app/shared/services/student-dossier-edit.service";
+import { ToastService } from "src/app/shared/services/toast.service";
+import { fileType } from "src/app/shared/validators/file-type.validator";
+import { maxFileSize } from "src/app/shared/validators/max-file-size.validator";
+import { BacklinkComponent } from "../../backlink/backlink.component";
+import { ButtonGroupComponent } from "../../button-group/button-group.component";
+import { FileInputComponent } from "../../file-input/file-input.component";
+import { FormErrorsComponent } from "../../form-errors/form-errors.component";
+import { SelectComponent } from "../../select/select.component";
+import { SpinnerComponent } from "../../spinner/spinner.component";
+import { SubmitButtonComponent } from "../../submit-button/submit-button.component";
+
+type DossierEntryFormData = {
+  type: "document" | "note";
+  file: Option<File>;
+  designation: string;
+  description: string;
+  category: Option<DropDownItem["Key"]>;
+  forTeacher: "class-teacher-only" | "all";
+  forStudent: boolean;
+};
+
+const CLASS_TEACHER_OBJECT_TYPE_ID = 2;
+const ALL_TEACHERS_OBJECT_TYPE_ID = 3;
+
+@Component({
+  selector: "bkd-student-dossier-edit",
+  imports: [
+    RouterLink,
+    FormField,
+    TranslatePipe,
+    BacklinkComponent,
+    SpinnerComponent,
+    ButtonGroupComponent,
+    FileInputComponent,
+    SelectComponent,
+    FormErrorsComponent,
+    SubmitButtonComponent,
+  ],
+  providers: [StudentDossierEditService],
+  templateUrl: "./student-dossier-edit.component.html",
+  styleUrl: "./student-dossier-edit.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StudentDossierEditComponent {
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+  private translate = inject(TranslateService);
+  private editService = inject(StudentDossierEditService);
+  private toastService = inject(ToastService);
+  private settings = inject<Settings>(SETTINGS);
+
+  acceptedFileTypes = this.settings.dossierAllowedFileTypes;
+
+  loading = toSignal(this.editService.loading$, { requireSync: true });
+  saving = signal(false);
+  studentId = toSignal(this.editService.studentId$, {
+    requireSync: true,
+  });
+  studentName = toSignal(this.editService.studentName$, { initialValue: null });
+  additionalInformationId = toSignal(
+    this.editService.additionalInformationId$,
+    {
+      requireSync: true,
+    },
+  );
+  additionalInformation = toSignal(this.editService.additionalInformation$, {
+    initialValue: null,
+  });
+  categories = toSignal(this.editService.categories$, {
+    initialValue: [],
+  });
+
+  heading = computed(() =>
+    this.additionalInformationId()
+      ? this.translate.instant("student.dossier.edit.title-update", {
+          designation: this.additionalInformation()?.Designation,
+        })
+      : this.translate.instant("student.dossier.edit.title-new"),
+  );
+
+  types = ["document", "note"].map((key) => ({
+    key,
+    label: this.translate.instant(`student.dossier.edit.type.${key}`),
+  }));
+
+  entryFormData = signal<DossierEntryFormData>({
+    type: "document",
+    file: null,
+    designation: "",
+    description: "",
+    category: null,
+    forTeacher: "class-teacher-only",
+    forStudent: true,
+  });
+  entryForm = form(this.entryFormData, (schema) => {
+    const isDocument = () => this.entryFormData().type === "document";
+    required(schema.type);
+    required(schema.file, {
+      when: isDocument,
+    });
+    maxFileSize(schema.file, {
+      maxBytes: this.settings.dossierMaxFileSize,
+      when: isDocument,
+    });
+    fileType(schema.file, {
+      acceptedFileTypes: this.acceptedFileTypes,
+      when: isDocument,
+    });
+    required(schema.designation);
+    required(schema.category);
+    required(schema.forTeacher);
+  });
+
+  submitted = signal(false);
+
+  async onSubmit(event: Event) {
+    event.preventDefault();
+    this.submitted.set(true);
+
+    if (this.entryForm().invalid()) {
+      return;
+    }
+
+    this.saving.set(true);
+    try {
+      const entry = await this.buildEntry(
+        this.studentId(),
+        this.entryFormData(),
+      );
+      const { type, file } = this.entryForm().value();
+      const success = await this.saveEntry(type, entry, file);
+      if (success) {
+        this.toastService.success(
+          this.translate.instant("student.dossier.edit.save-success"),
+        );
+        await this.navigateBack();
+      } else {
+        this.toastService.error(
+          this.translate.instant("student.dossier.edit.save-error"),
+        );
+      }
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  private async buildEntry(
+    studentId: Option<number>,
+    formData: DossierEntryFormData,
+  ): Promise<Partial<AdditionalInformation>> {
+    const { designation, description, category, forTeacher, forStudent } =
+      formData;
+
+    return {
+      ObjectId: await this.getObjectId(studentId, forTeacher),
+      ObjectTypeId:
+        forTeacher === "class-teacher-only"
+          ? CLASS_TEACHER_OBJECT_TYPE_ID
+          : ALL_TEACHERS_OBJECT_TYPE_ID,
+      TypeId: this.settings.dossierCreateTypeId,
+      CodeId: category == null ? null : Number(category),
+      Designation: designation?.trim(),
+      Description: description?.trim() || null,
+      ForStudent: forStudent,
+    };
+  }
+
+  /**
+   * If visible for all teachers of the class (incl. "Fachlehrpersonen"), the
+   * entry is attached to the person. If visible only to the class teacher, the
+   * entry is attached to the subscription (i.e. "Fach").
+   */
+  private async getObjectId(
+    studentId: Option<number>,
+    forTeacher: DossierEntryFormData["forTeacher"],
+  ): Promise<number> {
+    if (studentId == null) {
+      throw new Error("Student ID not present");
+    }
+
+    if (forTeacher === "class-teacher-only") {
+      const subscriptionId =
+        await this.editService.getSubscriptionId(studentId);
+      if (!subscriptionId) {
+        throw new Error("Subscription ID not found");
+      }
+      return subscriptionId;
+    }
+
+    return studentId;
+  }
+
+  private async saveEntry(
+    type: "document" | "note",
+    entry: Partial<AdditionalInformation>,
+    file: Option<File>,
+  ): Promise<boolean> {
+    try {
+      await this.editService.save(type, entry, file);
+      return true;
+    } catch (error) {
+      console.error("Failed to save entry:", error);
+      return false;
+    }
+  }
+
+  private async navigateBack(): Promise<void> {
+    await this.router.navigate(["../../"], { relativeTo: this.route });
+  }
+}

--- a/src/app/shared/components/student/student-grades-edit-dialog/student-grades-edit-dialog.component.ts
+++ b/src/app/shared/components/student/student-grades-edit-dialog/student-grades-edit-dialog.component.ts
@@ -116,8 +116,8 @@ export class StudentGradesEditDialogComponent implements OnInit {
     );
   }
 
-  onGradeChange(gradeId: Option<number>): void {
-    this.gradeSubject$.next(gradeId);
+  onGradeChange(gradeId: Option<DropDownItem["Key"]>): void {
+    this.gradeSubject$.next(gradeId == null ? null : Number(gradeId));
   }
 
   onPointsChange(points: string): void {

--- a/src/app/shared/components/student/student-navigation/student-navigation.component.ts
+++ b/src/app/shared/components/student/student-navigation/student-navigation.component.ts
@@ -3,7 +3,7 @@ import { RouterLink, RouterLinkActive } from "@angular/router";
 import { TranslatePipe } from "@ngx-translate/core";
 import { StudentWithClassRegistration } from "src/app/shared/models/student.model";
 import { StudentAvatarComponent } from "../student-avatar/student-avatar.component";
-import { STUDENT_PAGES } from "../student-route";
+import { STUDENT_PAGES } from "../student-pages";
 
 @Component({
   selector: "bkd-student-navigation",

--- a/src/app/shared/components/student/student-pages.ts
+++ b/src/app/shared/components/student/student-pages.ts
@@ -1,0 +1,16 @@
+import { Route } from "@angular/router";
+import { StudentAbsencesComponent } from "./student-absences/student-absences.component";
+import { StudentContactComponent } from "./student-contact/student-contact.component";
+import { StudentDossierComponent } from "./student-dossier/student-dossier.component";
+import { StudentGradesComponent } from "./student-grades/student-grades.component";
+
+// Defined the student child routes here (rather than in student-route.ts) to
+// avoid a circular dependency.
+export const studentPageRoutes: ReadonlyArray<Route> = [
+  { path: "contact", component: StudentContactComponent },
+  { path: "absences", component: StudentAbsencesComponent },
+  { path: "grades", component: StudentGradesComponent },
+  { path: "dossier", component: StudentDossierComponent },
+];
+
+export const STUDENT_PAGES = studentPageRoutes.map(({ path }) => path!);

--- a/src/app/shared/components/student/student-route.ts
+++ b/src/app/shared/components/student/student-route.ts
@@ -1,42 +1,23 @@
 import { Route } from "@angular/router";
+import { StudentStateService } from "../../services/student-state.service";
 import { ConfirmAbsencesComponent } from "../confirm-absences/confirm-absences.component";
-import { StudentAbsencesComponent } from "./student-absences/student-absences.component";
-import { StudentContactComponent } from "./student-contact/student-contact.component";
-import { StudentDossierComponent } from "./student-dossier/student-dossier.component";
-import { StudentGradesComponent } from "./student-grades/student-grades.component";
+import { StudentDossierEditComponent } from "./student-dossier-edit/student-dossier-edit.component";
+import { studentPageRoutes } from "./student-pages";
 import { StudentComponent } from "./student/student.component";
 
 export const studentRoute: Route = {
   path: "student/:id",
+  providers: [StudentStateService],
   children: [
     {
       path: "",
-      get component() {
-        // Avoid circular dependency caused by StudentComponent importing
-        // STUDENT_PAGES and this file importing the component, while it is not
-        // yet defined.
-        return StudentComponent;
-      },
-      children: [
-        {
-          path: "contact",
-          component: StudentContactComponent,
-        },
-        {
-          path: "absences",
-          component: StudentAbsencesComponent,
-        },
-        { path: "grades", component: StudentGradesComponent },
-        { path: "dossier", component: StudentDossierComponent },
-      ],
+      component: StudentComponent,
+      children: [...studentPageRoutes],
     },
     {
       path: "absences/confirm",
       component: ConfirmAbsencesComponent,
     },
+    { path: "dossier/edit/:id", component: StudentDossierEditComponent },
   ],
 };
-
-export const STUDENT_PAGES = (
-  (studentRoute.children ?? [])[0].children ?? []
-).map(({ path }) => path);

--- a/src/app/shared/components/student/student/student.component.ts
+++ b/src/app/shared/components/student/student/student.component.ts
@@ -23,7 +23,7 @@ import { StudentNavigationComponent } from "../student-navigation/student-naviga
     StudentDossierActionsComponent,
     StudentGradesActionsComponent,
   ],
-  providers: [StudentStateService, StudentGradesService],
+  providers: [StudentGradesService],
 })
 export class StudentComponent {
   private state = inject(StudentStateService);

--- a/src/app/shared/components/submit-button/submit-button.component.html
+++ b/src/app/shared/components/submit-button/submit-button.component.html
@@ -1,0 +1,12 @@
+<button
+  type="submit"
+  class="btn btn-primary"
+  [disabled]="disabled() || saving()"
+>
+  <ng-content></ng-content>
+  @if (saving()) {
+    <div class="spinner-border spinner-border-sm align-middle" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  }
+</button>

--- a/src/app/shared/components/submit-button/submit-button.component.spec.ts
+++ b/src/app/shared/components/submit-button/submit-button.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { SubmitButtonComponent } from "./submit-button.component";
+
+describe("SubmitButtonComponent", () => {
+  let fixture: ComponentFixture<SubmitButtonComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SubmitButtonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubmitButtonComponent);
+    element = fixture.debugElement.nativeElement;
+    fixture.detectChanges();
+  });
+
+  it("is active and does not show spinner per default", () => {
+    const button = element.querySelector<HTMLButtonElement>(".btn");
+    expect(button?.disabled).toBeFalse();
+
+    const spinner = element.querySelector(".spinner-border");
+    expect(spinner).toBeNull();
+  });
+
+  it("is disabled and shows spinner when saving=true", () => {
+    fixture.componentRef.setInput("saving", true);
+    fixture.detectChanges();
+
+    const button = element.querySelector<HTMLButtonElement>(".btn");
+    expect(button?.disabled).toBeTrue();
+
+    const spinner = element.querySelector(".spinner-border");
+    expect(spinner).not.toBeNull();
+  });
+
+  it("is disabled and does not show spinner when disabled=true", () => {
+    fixture.componentRef.setInput("disabled", true);
+    fixture.detectChanges();
+
+    const button = element.querySelector<HTMLButtonElement>(".btn");
+    expect(button?.disabled).toBeTrue();
+
+    const spinner = element.querySelector(".spinner-border");
+    expect(spinner).toBeNull();
+  });
+});

--- a/src/app/shared/components/submit-button/submit-button.component.ts
+++ b/src/app/shared/components/submit-button/submit-button.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+
+@Component({
+  selector: "bkd-submit-button",
+  imports: [],
+  templateUrl: "./submit-button.component.html",
+  styleUrl: "./submit-button.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubmitButtonComponent {
+  disabled = input(false);
+  saving = input(false);
+}

--- a/src/app/shared/models/additional-informations.model.ts
+++ b/src/app/shared/models/additional-informations.model.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts";
 import { LocalDateTimeFromString, Option } from "./common-types";
+import { DropDownItem } from "./drop-down-item.model";
 
 const AdditionalInformation = t.type({
   Id: t.number,
@@ -19,5 +20,14 @@ const AdditionalInformation = t.type({
   // "HRef": "/restApi/AdditionalInformations/1001"
 });
 
+const AdditionalInformationCode = t.intersection([
+  DropDownItem,
+  t.type({
+    IsActive: t.boolean,
+    Sort: t.string,
+  }),
+]);
+
 type AdditionalInformation = t.TypeOf<typeof AdditionalInformation>;
-export { AdditionalInformation };
+type AdditionalInformationCode = t.TypeOf<typeof AdditionalInformationCode>;
+export { AdditionalInformation, AdditionalInformationCode };

--- a/src/app/shared/services/additional-informations-rest.service.spec.ts
+++ b/src/app/shared/services/additional-informations-rest.service.spec.ts
@@ -21,19 +21,14 @@ describe("AdditionalInformationsRestService", () => {
     httpTestingController.verify();
   });
 
-  describe(".uploadPhoto", () => {
-    it("emits an error if the file is not a .jpg", () => {
+  describe(".createWithFile", () => {
+    it("emits an error if entry creation request fails", () => {
       service
-        .uploadPhoto(1, new File([], "test.png"))
-        .subscribe({ next: successCallback, error: errorCallback });
-
-      expect(errorCallback).toHaveBeenCalled();
-      expect(successCallback).not.toHaveBeenCalled();
-    });
-
-    it("emits an error if uploading a .jpg error and metadata request fails", () => {
-      service
-        .uploadPhoto(1, new File([], "test.jpg"))
+        .createWithFile(
+          { Designation: "Anruf Eltern", CodeId: 2000267 },
+          new File([], "test.pdf"),
+          "test.pdf",
+        )
         .subscribe({ next: successCallback, error: errorCallback });
 
       httpTestingController
@@ -47,9 +42,13 @@ describe("AdditionalInformationsRestService", () => {
       expect(successCallback).not.toHaveBeenCalled();
     });
 
-    it("emits an error if uploading a .jpg error and file request fails", () => {
+    it("emits an error if entry creation was successful but file upload request fails", () => {
       service
-        .uploadPhoto(1, new File([], "test.jpg"))
+        .createWithFile(
+          { Designation: "Anruf Eltern", CodeId: 2000267 },
+          new File([], "test.pdf"),
+          "test.pdf",
+        )
         .subscribe({ next: successCallback, error: errorCallback });
 
       httpTestingController
@@ -71,9 +70,88 @@ describe("AdditionalInformationsRestService", () => {
       expect(successCallback).not.toHaveBeenCalled();
     });
 
-    it("uploads the image file if it is a .jpg", () => {
+    it("successfully creates the entry & uploads the image file", () => {
       service
-        .uploadPhoto(1, new File([], "test.jpg"))
+        .createWithFile(
+          { Designation: "Anruf Eltern", CodeId: 2000267 },
+          new File([], "test.pdf"),
+          "test.pdf",
+        )
+        .subscribe({ next: successCallback, error: errorCallback });
+
+      httpTestingController
+        .expectOne("https://eventotest.api/AdditionalInformations/files")
+        .flush(null, {
+          status: 201,
+          statusText: "Created",
+          headers: {
+            location: "/restApi/files/b87caa81-1de6-40d2-8bca-e461c8e760ab",
+          },
+        });
+      httpTestingController
+        .expectOne(
+          "https://eventotest.api/restApi/files/b87caa81-1de6-40d2-8bca-e461c8e760ab",
+        )
+        .flush(null, { status: 201, statusText: "Created" });
+
+      expect(successCallback).toHaveBeenCalled();
+      expect(errorCallback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(".createAvatar", () => {
+    it("emits an error if the file is not a .jpg", () => {
+      service
+        .createAvatar(1, new File([], "test.png"))
+        .subscribe({ next: successCallback, error: errorCallback });
+
+      expect(errorCallback).toHaveBeenCalled();
+      expect(successCallback).not.toHaveBeenCalled();
+    });
+
+    it("emits an error if entry creation request fails", () => {
+      service
+        .createAvatar(1, new File([], "test.jpg"))
+        .subscribe({ next: successCallback, error: errorCallback });
+
+      httpTestingController
+        .expectOne("https://eventotest.api/AdditionalInformations/files")
+        .flush(null, {
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+
+      expect(errorCallback).toHaveBeenCalled();
+      expect(successCallback).not.toHaveBeenCalled();
+    });
+
+    it("emits an error if entry creation was successful but file upload request fails", () => {
+      service
+        .createAvatar(1, new File([], "test.jpg"))
+        .subscribe({ next: successCallback, error: errorCallback });
+
+      httpTestingController
+        .expectOne("https://eventotest.api/AdditionalInformations/files")
+        .flush(null, {
+          status: 201,
+          statusText: "Created",
+          headers: {
+            location: "/restApi/files/b87caa81-1de6-40d2-8bca-e461c8e760ab",
+          },
+        });
+      httpTestingController
+        .expectOne(
+          "https://eventotest.api/restApi/files/b87caa81-1de6-40d2-8bca-e461c8e760ab",
+        )
+        .flush(null, { status: 500, statusText: "Internal Server Error" });
+
+      expect(errorCallback).toHaveBeenCalled();
+      expect(successCallback).not.toHaveBeenCalled();
+    });
+
+    it("successfully creates the entry & uploads the image file", () => {
+      service
+        .createAvatar(1, new File([], "test.jpg"))
         .subscribe({ next: successCallback, error: errorCallback });
 
       httpTestingController

--- a/src/app/shared/services/additional-informations-rest.service.ts
+++ b/src/app/shared/services/additional-informations-rest.service.ts
@@ -3,36 +3,56 @@ import { Injectable, inject } from "@angular/core";
 import { Observable, map, switchMap, throwError } from "rxjs";
 import { SETTINGS, Settings } from "src/app/settings";
 import { RestErrorInterceptorOptions } from "../interceptors/rest-error.interceptor";
+import { AdditionalInformation } from "../models/additional-informations.model";
+import { RestService } from "./rest.service";
 
 @Injectable({
   providedIn: "root",
 })
-export class AdditionalInformationsRestService {
-  private http = inject(HttpClient);
-  private settings = inject<Settings>(SETTINGS);
+export class AdditionalInformationsRestService extends RestService<
+  typeof AdditionalInformation
+> {
+  constructor() {
+    const http = inject(HttpClient);
+    const settings = inject<Settings>(SETTINGS);
 
-  uploadPhoto(studentId: number, file: File): Observable<void> {
-    return this.preparePhotoUpload(studentId, file).pipe(
-      switchMap((photoUploadPath) =>
-        this.http.put(
-          `${this.settings.apiUrl.replace("/restApi", "")}${photoUploadPath}`,
-          file,
-          {
-            headers: { "Content-Type": file.type },
-            context: new HttpContext().set(RestErrorInterceptorOptions, {
-              disableErrorHandling: true,
-            }),
-          },
-        ),
-      ),
-      map(() => undefined),
+    super(http, settings, AdditionalInformation, "AdditionalInformations");
+  }
+
+  /**
+   * Creates an AdditionalInformation entry.
+   */
+  create(
+    entry: Partial<AdditionalInformation>,
+    options: { context?: HttpContext } = {},
+  ): Observable<void> {
+    return this.http
+      .post(`${this.baseUrl}/`, entry, options)
+      .pipe(map(() => undefined));
+  }
+
+  /**
+   * Creates an AdditionalInformation entry with an associated file (two
+   * requests). Error responses are not handled by the interceptor and must be
+   * handled by the consumer.
+   */
+  createWithFile(
+    entry: Partial<AdditionalInformation>,
+    file: File,
+    filename: string,
+  ): Observable<void> {
+    return this.createFileEntry(entry, filename).pipe(
+      switchMap(({ fileUploadPath }) => this.uploadFile(file, fileUploadPath)),
     );
   }
 
-  private preparePhotoUpload(
-    studentId: number,
-    file: File,
-  ): Observable<Option<string>> {
+  /**
+   * Uploads the avatar image (two requests). Error responses are not handled by
+   * the interceptor and must be handled by the consumer.
+   */
+  createAvatar(studentId: number, file: File): Observable<void> {
+    // The filename must be ".jpg" (lowercase) or the backend won't process it
+    // (and there won't be any error)
     const filename = file.name.replace(/\.jpe?g$/i, ".jpg");
     if (!filename.endsWith(".jpg")) {
       return throwError(
@@ -40,14 +60,29 @@ export class AdditionalInformationsRestService {
       );
     }
 
-    const body = {
-      AdditionalInformation: {
+    return this.createWithFile(
+      {
         ObjectId: studentId,
         ObjectTypeId: 3,
         Designation: "Photo",
       },
+      file,
+      filename,
+    );
+  }
+
+  /**
+   * Create an AdditionalInformations entry with an associated file. The file
+   * itself must then be uploaded in a second request using {@link uploadFile}
+   * and the returned `fileUploadPath`.
+   */
+  private createFileEntry(
+    entry: Partial<AdditionalInformation>,
+    filename: string,
+  ): Observable<{ fileUploadPath: string }> {
+    const body = {
+      AdditionalInformation: entry,
       FileStreamInfo: {
-        // The filename must be ".jpg" (lowercase) or the backend won't process it (and there won't be any error)
         Filename: filename,
       },
     };
@@ -61,18 +96,33 @@ export class AdditionalInformationsRestService {
       .pipe(
         map((response) => {
           if (response.status !== 201) {
-            throw new Error("Failed to get photo upload path");
+            throw new Error("Failed to get file upload path");
           }
-          const uploadPath = response.headers.get("Location");
-          if (!uploadPath) {
-            throw new Error("Invalid photo upload path");
+          const fileUploadPath = response.headers.get("Location");
+          if (!fileUploadPath) {
+            throw new Error("Invalid file upload path");
           }
-          return uploadPath;
+          return { fileUploadPath };
         }),
       );
   }
 
-  private get baseUrl(): string {
-    return `${this.settings.apiUrl}/AdditionalInformations`;
+  /**
+   * Upload the actual file using the `fileUploadPath` as returned by
+   * {@link createFileEntry}.
+   */
+  private uploadFile(file: File, fileUploadPath: string): Observable<void> {
+    return this.http
+      .put(
+        `${this.settings.apiUrl.replace("/restApi", "")}${fileUploadPath}`,
+        file,
+        {
+          headers: { "Content-Type": file.type },
+          context: new HttpContext().set(RestErrorInterceptorOptions, {
+            disableErrorHandling: true,
+          }),
+        },
+      )
+      .pipe(map(() => undefined));
   }
 }

--- a/src/app/shared/services/drop-down-items-rest.service.ts
+++ b/src/app/shared/services/drop-down-items-rest.service.ts
@@ -3,6 +3,7 @@ import { Injectable, inject } from "@angular/core";
 import { Observable } from "rxjs";
 import { shareReplay, switchMap } from "rxjs/operators";
 import { SETTINGS, Settings } from "src/app/settings";
+import { AdditionalInformationCode } from "../models/additional-informations.model";
 import { DropDownItem } from "../models/drop-down-item.model";
 import { decodeArray } from "../utils/decode";
 
@@ -31,10 +32,12 @@ export class DropDownItemsRestService {
       .pipe(switchMap(decodeArray(DropDownItem)), shareReplay(1));
   }
 
-  getAdditionalInformationCodes(): Observable<ReadonlyArray<DropDownItem>> {
+  getAdditionalInformationCodes(): Observable<
+    ReadonlyArray<AdditionalInformationCode>
+  > {
     return this.http
       .get<unknown>(`${this.baseUrl}/AdditionalInformationCodes`)
-      .pipe(switchMap(decodeArray(DropDownItem)), shareReplay(1));
+      .pipe(switchMap(decodeArray(AdditionalInformationCode)), shareReplay(1));
   }
 
   private get baseUrl(): string {

--- a/src/app/shared/services/student-dossier-edit.service.spec.ts
+++ b/src/app/shared/services/student-dossier-edit.service.spec.ts
@@ -1,0 +1,249 @@
+import { HttpErrorResponse } from "@angular/common/http";
+import { TestBed } from "@angular/core/testing";
+import { ActivatedRoute, ParamMap, convertToParamMap } from "@angular/router";
+import { BehaviorSubject, firstValueFrom, of, throwError } from "rxjs";
+import {
+  buildAdditionalInformation,
+  buildStudent,
+  buildSubscription,
+} from "src/spec-builders";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { AdditionalInformation } from "../models/additional-informations.model";
+import { AdditionalInformationsRestService } from "./additional-informations-rest.service";
+import { DropDownItemsRestService } from "./drop-down-items-rest.service";
+import { LoadingService } from "./loading-service";
+import { StudentDossierEditService } from "./student-dossier-edit.service";
+import { StudentStateService } from "./student-state.service";
+import { SubscriptionsRestService } from "./subscriptions-rest.service";
+
+describe("StudentDossierEditService", () => {
+  let service: StudentDossierEditService;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+  let studentStateService: jasmine.SpyObj<StudentStateService>;
+  let additionalInformationsService: jasmine.SpyObj<AdditionalInformationsRestService>;
+  let dropDownItemsService: jasmine.SpyObj<DropDownItemsRestService>;
+  let subscriptionsService: jasmine.SpyObj<SubscriptionsRestService>;
+  let routeParams: BehaviorSubject<ParamMap>;
+  let parentRouteParams: BehaviorSubject<ParamMap>;
+  let additionalInformation: AdditionalInformation;
+
+  beforeEach(() => {
+    routeParams = new BehaviorSubject(convertToParamMap({ id: "1" }));
+    parentRouteParams = new BehaviorSubject(convertToParamMap({ id: "42" }));
+
+    activatedRoute = jasmine.createSpyObj<ActivatedRoute>(
+      "ActivatedRoute",
+      [],
+      {
+        paramMap: routeParams,
+        parent: {
+          paramMap: parentRouteParams,
+        } as unknown as ActivatedRoute,
+      },
+    );
+
+    studentStateService = jasmine.createSpyObj<StudentStateService>(
+      "StudentStateService",
+      [],
+      {
+        studentId$: of(42),
+        student$: of({ ...buildStudent(42), ClassRegistrations: [] }),
+      },
+    );
+
+    additionalInformationsService =
+      jasmine.createSpyObj<AdditionalInformationsRestService>(
+        "AdditionalInformationsRestService",
+        ["get", "create", "createWithFile"],
+      );
+    additionalInformation = buildAdditionalInformation();
+    additionalInformationsService.get.and.returnValue(
+      of(additionalInformation),
+    );
+    additionalInformationsService.create.and.returnValue(of(undefined));
+    additionalInformationsService.createWithFile.and.returnValue(of(undefined));
+
+    dropDownItemsService = jasmine.createSpyObj<DropDownItemsRestService>(
+      "DropDownItemsRestService",
+      ["getAdditionalInformationCodes"],
+    );
+    dropDownItemsService.getAdditionalInformationCodes.and.returnValue(
+      of([
+        {
+          Key: 2000267,
+          Value: "Administration",
+          IsActive: true,
+          Sort: "1011",
+        },
+        {
+          Key: 2000268,
+          Value: "Ärztliches Attest",
+          IsActive: true,
+          Sort: "1011",
+        },
+        {
+          // Inactive
+          Key: 2000271,
+          Value: "Disziplinarisch",
+          IsActive: false,
+          Sort: "1011",
+        },
+        {
+          // Other type
+          Key: 2000272,
+          Value: "Gesuch",
+          IsActive: true,
+          Sort: "0",
+        },
+      ]),
+    );
+
+    subscriptionsService = jasmine.createSpyObj<SubscriptionsRestService>(
+      "SubscriptionsRestService",
+      ["getList"],
+    );
+    subscriptionsService.getList.and.returnValue(
+      of([buildSubscription(10, 11, 12), buildSubscription(20, 21, 22)]),
+    );
+
+    TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        providers: [
+          LoadingService,
+          { provide: ActivatedRoute, useValue: activatedRoute },
+          { provide: StudentStateService, useValue: studentStateService },
+          {
+            provide: AdditionalInformationsRestService,
+            useValue: additionalInformationsService,
+          },
+          { provide: DropDownItemsRestService, useValue: dropDownItemsService },
+          { provide: SubscriptionsRestService, useValue: subscriptionsService },
+        ],
+      }),
+    );
+    service = TestBed.inject(StudentDossierEditService);
+  });
+
+  describe("studentId$", () => {
+    it("emits the student id from the route params", async () => {
+      const studentId = await firstValueFrom(service.studentId$);
+      expect(studentId).toBe(42);
+    });
+  });
+
+  describe("studentName$", () => {
+    it("emits the student name", async () => {
+      const studentName = await firstValueFrom(service.studentName$);
+      expect(studentName).toBe("T. Tux");
+    });
+  });
+
+  describe("additionalInformationId$", () => {
+    it("emits null for new entry", async () => {
+      routeParams.next(convertToParamMap({ id: "new" }));
+      const additionalInformationId = await firstValueFrom(
+        service.additionalInformationId$,
+      );
+      expect(additionalInformationId).toBeNull();
+    });
+
+    it("emits the ID for existing entries", async () => {
+      const additionalInformationId = await firstValueFrom(
+        service.additionalInformationId$,
+      );
+      expect(additionalInformationId).toBe(1);
+    });
+  });
+
+  describe("additionalInformation$", () => {
+    it("emits the additional information entry if it exists", async () => {
+      const entry = await firstValueFrom(service.additionalInformation$);
+      expect(entry).toBe(additionalInformation);
+    });
+
+    it("emits null for new entry", async () => {
+      routeParams.next(convertToParamMap({ id: "new" }));
+      const entry = await firstValueFrom(service.additionalInformation$);
+      expect(entry).toBeNull();
+    });
+
+    it("emits null if the response is a 404", async () => {
+      const error = new HttpErrorResponse({ status: 404 });
+      additionalInformationsService.get.and.returnValue(
+        throwError(() => error),
+      );
+
+      const entry = await firstValueFrom(service.additionalInformation$);
+      expect(entry).toBeNull();
+    });
+  });
+
+  describe("categories$", () => {
+    it("emits active categories of type 1011", async () => {
+      const categories = await firstValueFrom(service.categories$);
+      expect(categories).toEqual([
+        {
+          Key: 2000267,
+          Value: "Administration",
+          IsActive: true,
+          Sort: "1011",
+        },
+        {
+          Key: 2000268,
+          Value: "Ärztliches Attest",
+          IsActive: true,
+          Sort: "1011",
+        },
+      ]);
+    });
+  });
+
+  describe("getSubscriptionId", () => {
+    it("returns the ID of the first subscription of the student", async () => {
+      const id = await service.getSubscriptionId(42);
+      expect(id).toBe(10);
+      expect(subscriptionsService.getList).toHaveBeenCalledWith({
+        params: {
+          "filter.IsOkay": "=1",
+          "filter.PersonId": "=42",
+        },
+      });
+    });
+  });
+
+  describe("save", () => {
+    describe("note", () => {
+      it("creates an entry", async () => {
+        await service.save("note", additionalInformation, null);
+        expect(additionalInformationsService.create).toHaveBeenCalledWith(
+          additionalInformation,
+          jasmine.any(Object),
+        );
+        expect(
+          additionalInformationsService.createWithFile,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("document", () => {
+      it("creates a file entry", async () => {
+        const file = new File([], "test.pdf");
+        await service.save("document", additionalInformation, file);
+        expect(
+          additionalInformationsService.createWithFile,
+        ).toHaveBeenCalledWith(additionalInformation, file, "test.pdf");
+        expect(additionalInformationsService.create).not.toHaveBeenCalled();
+      });
+
+      it("throws an error if file is not present", async () => {
+        await expectAsync(
+          service.save("document", additionalInformation, null),
+        ).toBeRejectedWithError("File is not present");
+        expect(
+          additionalInformationsService.createWithFile,
+        ).not.toHaveBeenCalled();
+        expect(additionalInformationsService.create).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/app/shared/services/student-dossier-edit.service.ts
+++ b/src/app/shared/services/student-dossier-edit.service.ts
@@ -1,0 +1,132 @@
+import { HttpContext } from "@angular/common/http";
+import { Injectable, inject } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import {
+  Observable,
+  firstValueFrom,
+  map,
+  of,
+  shareReplay,
+  switchMap,
+} from "rxjs";
+import { SETTINGS, Settings } from "src/app/settings";
+import { RestErrorInterceptorOptions } from "src/app/shared/interceptors/rest-error.interceptor";
+import {
+  AdditionalInformation,
+  AdditionalInformationCode,
+} from "src/app/shared/models/additional-informations.model";
+import { AdditionalInformationsRestService } from "src/app/shared/services/additional-informations-rest.service";
+import { LoadingService } from "src/app/shared/services/loading-service";
+import { catch404 } from "src/app/shared/utils/observable";
+import { UnreachableError } from "../utils/error";
+import { DropDownItemsRestService } from "./drop-down-items-rest.service";
+import { StudentStateService } from "./student-state.service";
+import { SubscriptionsRestService } from "./subscriptions-rest.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class StudentDossierEditService {
+  private route = inject(ActivatedRoute);
+  private studentState = inject(StudentStateService);
+  private additionalInformationsService = inject(
+    AdditionalInformationsRestService,
+  );
+  private dropDownItemsService = inject(DropDownItemsRestService);
+  private subscriptionsService = inject(SubscriptionsRestService);
+  private loadingService = inject(LoadingService);
+  private settings = inject<Settings>(SETTINGS);
+
+  loading$ = this.loadingService.loading$;
+  studentId$ = this.studentState.studentId$;
+  studentName$ = this.studentState.student$.pipe(
+    map((student) => student?.FullName ?? null),
+  );
+  additionalInformationId$ = this.route.paramMap.pipe(
+    map((params) => {
+      const id = params.get("id");
+      return id === "new" ? null : Number(id);
+    }),
+  );
+  additionalInformation$ = this.additionalInformationId$.pipe(
+    switchMap(this.loadAdditionalInformation.bind(this)),
+    shareReplay(1),
+  );
+  categories$ = this.loadCategories().pipe(shareReplay(1));
+
+  async getSubscriptionId(studentId: number): Promise<Option<number>> {
+    const subscriptions = await firstValueFrom(
+      this.subscriptionsService.getList({
+        params: {
+          "filter.IsOkay": "=1",
+          "filter.PersonId": `=${studentId}`,
+        },
+      }),
+    );
+    return subscriptions[0]?.Id ?? null;
+  }
+
+  async save(
+    type: "document" | "note",
+    entry: Partial<AdditionalInformation>,
+    file: Option<File>,
+  ): Promise<void> {
+    let save$: Observable<void>;
+    switch (type) {
+      case "document":
+        if (!file) {
+          throw new Error("File is not present");
+        }
+        save$ = this.additionalInformationsService.createWithFile(
+          entry,
+          file,
+          file.name,
+        );
+        break;
+      case "note":
+        save$ = this.additionalInformationsService.create(entry, {
+          context: new HttpContext().set(RestErrorInterceptorOptions, {
+            disableErrorHandling: true,
+          }),
+        });
+        break;
+      default:
+        throw new UnreachableError(type, "Unhandled type");
+    }
+    await firstValueFrom(save$);
+  }
+
+  private loadCategories(): Observable<
+    ReadonlyArray<AdditionalInformationCode>
+  > {
+    return this.loadingService.load(
+      this.dropDownItemsService.getAdditionalInformationCodes().pipe(
+        map((categories) =>
+          categories.filter(
+            (category) =>
+              category.IsActive &&
+              // As a workaround, the type id of the category is in the `Sort`
+              // field. Use this to exclude duplicate categories.
+              category.Sort === String(this.settings.dossierCategoriesTypeId),
+          ),
+        ),
+      ),
+    );
+  }
+
+  private loadAdditionalInformation(
+    additionalInformationId: Option<number>,
+  ): Observable<Option<AdditionalInformation>> {
+    if (!additionalInformationId) return of(null);
+
+    return this.loadingService.load(
+      this.additionalInformationsService
+        .get(additionalInformationId, {
+          context: new HttpContext().set(RestErrorInterceptorOptions, {
+            disableErrorHandlingForStatus: [404],
+          }),
+        })
+        .pipe(catch404()),
+    );
+  }
+}

--- a/src/app/shared/services/student-state.service.ts
+++ b/src/app/shared/services/student-state.service.ts
@@ -1,7 +1,15 @@
 import { Injectable, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, NavigationEnd, Router } from "@angular/router";
-import { filter, map, of, shareReplay, startWith, switchMap } from "rxjs";
+import {
+  distinctUntilChanged,
+  filter,
+  map,
+  of,
+  shareReplay,
+  startWith,
+  switchMap,
+} from "rxjs";
 import { parseQueryString } from "../utils/url";
 import { StorageService } from "./storage.service";
 import { StudentProfileService } from "./student-profile.service";
@@ -23,12 +31,16 @@ export class StudentStateService {
     { requireSync: true },
   );
 
-  studentId$ = this.route.paramMap.pipe(
-    map((params) => {
+  studentId$ = this.router.events.pipe(
+    filter((e) => e instanceof NavigationEnd),
+    startWith(null),
+    map(() => {
+      const id = this.findRouteParam("id");
       // Fall back to current user if no id param is present (for my-dossier)
-      const id = params.get("id");
-      return Number(id ? id : this.storageService.getPayload()?.id_person);
+      return Number(id ?? this.storageService.getPayload()?.id_person);
     }),
+    distinctUntilChanged(),
+    shareReplay(1),
   );
 
   student$ = this.studentId$.pipe(
@@ -62,5 +74,15 @@ export class StudentStateService {
     const parts = pathname.split("/");
     const page = parts[parts.length - 1];
     return page;
+  }
+
+  private findRouteParam(name: string): Option<string> {
+    let current: Option<ActivatedRoute> = this.router.routerState.root;
+    while (current) {
+      const value = current.snapshot.paramMap.get(name);
+      if (value != null) return value;
+      current = current.firstChild;
+    }
+    return null;
   }
 }

--- a/src/app/shared/validators/file-type.validator.spec.ts
+++ b/src/app/shared/validators/file-type.validator.spec.ts
@@ -1,0 +1,111 @@
+import { WritableSignal, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { FieldTree, form } from "@angular/forms/signals";
+import { fileType } from "./file-type.validator";
+
+type Model = {
+  file: Option<File>;
+};
+
+const ACCEPTED_FILE_TYPES = ["application/pdf", "image/png"] as const;
+
+describe("fileType", () => {
+  let model: WritableSignal<Model>;
+  let testForm: FieldTree<Model>;
+
+  beforeEach(() => {
+    testForm = TestBed.runInInjectionContext(() => {
+      model = signal<Model>({ file: null });
+      return form(model, (schema) => {
+        fileType(schema.file, { acceptedFileTypes: ACCEPTED_FILE_TYPES });
+      });
+    });
+  });
+
+  it("is valid when file is null", () => {
+    testForm.file().value.set(null);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  it("is valid for a file with an accepted PDF type", () => {
+    const pdfFile = new File(["content"], "doc.pdf", {
+      type: "application/pdf",
+    });
+    testForm.file().value.set(pdfFile);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  it("is valid for a file with an accepted PNG type", () => {
+    const pngFile = new File(["content"], "image.png", {
+      type: "image/png",
+    });
+    testForm.file().value.set(pngFile);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  it("is invalid for a file with a disallowed type", () => {
+    const exeFile = new File(["content"], "bad.exe", {
+      type: "application/vnd.microsoft.portable-executable",
+    });
+    testForm.file().value.set(exeFile);
+
+    expect(testForm.file().valid()).toBe(false);
+    const errors = testForm.file().errors();
+    expect(errors.length).toBe(1);
+    const error = errors[0] as unknown as {
+      kind: string;
+      message: string;
+    };
+    expect(error.kind).toBe("fileType");
+    expect(error.message).toContain("not allowed");
+  });
+
+  describe("with 'when' condition", () => {
+    it("is valid when 'when' condition returns false", () => {
+      testForm = TestBed.runInInjectionContext(() => {
+        return form(model, (schema) => {
+          fileType(schema.file, {
+            acceptedFileTypes: ACCEPTED_FILE_TYPES,
+            when: () => false,
+          });
+        });
+      });
+
+      const exeFile = new File(["content"], "bad.exe", {
+        type: "application/vnd.microsoft.portable-executable",
+      });
+      testForm.file().value.set(exeFile);
+
+      expect(testForm.file().valid()).toBe(true);
+      expect(testForm.file().errors().length).toBe(0);
+    });
+
+    it("is invalid when 'when' condition returns true", () => {
+      testForm = TestBed.runInInjectionContext(() => {
+        return form(model, (schema) => {
+          fileType(schema.file, {
+            acceptedFileTypes: ACCEPTED_FILE_TYPES,
+            when: () => true,
+          });
+        });
+      });
+
+      const exeFile = new File(["content"], "bad.exe", {
+        type: "application/vnd.microsoft.portable-executable",
+      });
+      testForm.file().value.set(exeFile);
+
+      expect(testForm.file().valid()).toBe(false);
+      const errors = testForm.file().errors();
+      expect(errors.length).toBe(1);
+      const error = errors[0] as unknown as { kind: string };
+      expect(error.kind).toBe("fileType");
+    });
+  });
+});

--- a/src/app/shared/validators/file-type.validator.ts
+++ b/src/app/shared/validators/file-type.validator.ts
@@ -1,0 +1,27 @@
+import { SchemaPath, validate } from "@angular/forms/signals";
+
+export function fileType(
+  path: SchemaPath<Option<File>>,
+  {
+    acceptedFileTypes,
+    when,
+  }: {
+    /**
+     * An array of the allowed content types the file can have.
+     */
+    acceptedFileTypes: ReadonlyArray<string>;
+    when?: () => boolean;
+  },
+): void {
+  validate(path, ({ value }) => {
+    const file = value();
+    if (file && !acceptedFileTypes.includes(file.type) && (!when || when())) {
+      return {
+        kind: "fileType",
+        message: `The file type is not allowed.`,
+      };
+    }
+
+    return null;
+  });
+}

--- a/src/app/shared/validators/max-file-size.validator.spec.ts
+++ b/src/app/shared/validators/max-file-size.validator.spec.ts
@@ -1,0 +1,113 @@
+import { WritableSignal, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { FieldTree, form } from "@angular/forms/signals";
+import { maxFileSize } from "./max-file-size.validator";
+
+type Model = {
+  file: Option<File>;
+};
+
+describe("maxFileSize", () => {
+  let model: WritableSignal<Model>;
+  let testForm: FieldTree<Model>;
+
+  beforeEach(() => {
+    testForm = TestBed.runInInjectionContext(() => {
+      model = signal<Model>({ file: null });
+      return form(model, (schema) => {
+        maxFileSize(schema.file, { maxBytes: 1024 * 1024 });
+      });
+    });
+  });
+
+  it("is valid when file is null", () => {
+    testForm.file().value.set(null);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  it("is valid for a file that is smaller than the max size", () => {
+    const smallFile = new File(["x".repeat(500 * 1024)], "small.txt", {
+      type: "text/plain",
+    });
+    testForm.file().value.set(smallFile);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  it("is invalid for a file that is larger than the max size", () => {
+    const largeFile = new File(["x".repeat(2 * 1024 * 1024)], "large.txt", {
+      type: "text/plain",
+    });
+    testForm.file().value.set(largeFile);
+
+    expect(testForm.file().valid()).toBe(false);
+    const errors = testForm.file().errors();
+    expect(errors.length).toBe(1);
+    const error = errors[0] as unknown as {
+      kind: string;
+      message: string;
+      size: string;
+      maxSize: string;
+    };
+    expect(error.kind).toBe("maxFileSize");
+    expect(error.message).toContain("too large");
+    expect(error.size).toBe("2.0");
+    expect(error.maxSize).toBe("1.0");
+  });
+
+  it("is valid when file size equals max size", () => {
+    const exactFile = new File(["x".repeat(1024 * 1024)], "exact.txt", {
+      type: "text/plain",
+    });
+    testForm.file().value.set(exactFile);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
+  });
+
+  describe("with 'when' condition", () => {
+    it("is valid when 'when' condition returns false", () => {
+      testForm = TestBed.runInInjectionContext(() => {
+        return form(model, (schema) => {
+          maxFileSize(schema.file, {
+            maxBytes: 1024 * 1024,
+            when: () => false,
+          });
+        });
+      });
+
+      const largeFile = new File(["x".repeat(2 * 1024 * 1024)], "large.txt", {
+        type: "text/plain",
+      });
+      testForm.file().value.set(largeFile);
+
+      expect(testForm.file().valid()).toBe(true);
+      expect(testForm.file().errors().length).toBe(0);
+    });
+
+    it("is invalid when 'when' condition returns true", () => {
+      testForm = TestBed.runInInjectionContext(() => {
+        return form(model, (schema) => {
+          maxFileSize(schema.file, {
+            maxBytes: 1024 * 1024,
+            when: () => true,
+          });
+        });
+      });
+
+      const largeFile = new File(["x".repeat(2 * 1024 * 1024)], "large.txt", {
+        type: "text/plain",
+      });
+      testForm.file().value.set(largeFile);
+
+      expect(testForm.file().valid()).toBe(false);
+      const errors = testForm.file().errors();
+      expect(errors.length).toBe(1);
+      const error = errors[0] as unknown as { kind: string };
+      expect(error.kind).toBe("maxFileSize");
+    });
+  });
+});

--- a/src/app/shared/validators/max-file-size.validator.ts
+++ b/src/app/shared/validators/max-file-size.validator.ts
@@ -1,0 +1,22 @@
+import { SchemaPath, validate } from "@angular/forms/signals";
+
+export function maxFileSize(
+  path: SchemaPath<Option<File>>,
+  { maxBytes, when }: { maxBytes: number; when?: () => boolean },
+): void {
+  validate(path, ({ value }) => {
+    const file = value();
+    if (file && file.size > maxBytes && (!when || when())) {
+      const sizeMb = (file.size / 1024 / 1024).toFixed(1);
+      const maxSizeMb = (maxBytes / 1024 / 1024).toFixed(1);
+      return {
+        kind: "maxFileSize",
+        message: `The file is too large (${sizeMb} MB, max ${maxSizeMb} MB)`,
+        size: sizeMb,
+        maxSize: maxSizeMb,
+      };
+    }
+
+    return null;
+  });
+}

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -25,7 +25,9 @@
       "min": "Bitte geben Sie eine Zahl grösser oder gleich {{min}} ein.",
       "ngbDate": "Bitte geben Sie ein gültiges Datum ein.",
       "invalidPoints": "Bitte einen Wert von 0 bis {{ maxPoints }} eingeben.",
-      "greaterThan": "Bitte geben Sie eine Zahl grösser {{ greaterThanValue }} ein."
+      "greaterThan": "Bitte geben Sie eine Zahl grösser {{ greaterThanValue }} ein.",
+      "maxFileSize": "Die Datei ist zu gross ({{size}} MB, max. {{maxSize}} MB)",
+      "fileType": "Dieser Dateityp ist nicht erlaubt"
     },
     "pagination": {
       "load-more": "Weitere Einträge laden"
@@ -442,7 +444,28 @@
       "information": "Information",
       "download": "Anzeigen",
       "disadvantage": "Nachteilsausgleich",
-      "created": "Erstellt"
+      "created": "Erstellt",
+      "edit": {
+        "title-new": "Eintrag hinzufügen",
+        "title-update": "«{{designation}}» bearbeiten",
+        "not-found": "Der Eintrag konnte nicht gefunden werden.",
+        "type": {
+          "document": "Dokument",
+          "note": "Notiz"
+        },
+        "designation": "Titel",
+        "description": "Notizen",
+        "category": "Kategorie",
+        "visibility": "Sichtbarkeit",
+        "for-teacher-class-teacher-only": "Nur Klassenlehrperson",
+        "for-teacher-all": "Alle Lehrpersonen der Klasse",
+        "for-student": "Sichtbar für {{ studentName }}",
+        "optional": "optional",
+        "cancel": "Abbrechen",
+        "save": "Übernehmen",
+        "save-success": "Der Eintrag wurde gespeichert",
+        "save-error": "Der Eintrag konnte nicht gespeichert werden"
+      }
     }
   },
   "import": {

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -14,7 +14,9 @@
       "conflict-title": "Données non valides",
       "conflict-message": "Les données que vous souhaitez enregistrer ne sont pas valides.",
       "server-title": "Erreur du serveur",
-      "server-message": "Une erreur s'est produite lors de la connexion au serveur."
+      "server-message": "Une erreur s'est produite lors de la connexion au serveur.",
+      "maxFileSize": "La taille du fichier est trop grande ({{size}} MB, max. {{maxSize}} MB)",
+      "fileType": "Ce type de fichier n'est pas autorisé"
     },
     "validation-errors": {
       "required": "Ce champ doit être rempli.",
@@ -442,7 +444,28 @@
       "information": "Information",
       "download": "Afficher",
       "disadvantage": "Compensation des désavantages",
-      "created": "Créé"
+      "created": "Créé",
+      "edit": {
+        "title-new": "Ajouter une entrée",
+        "title-update": "Modifier « {{designation}} »",
+        "not-found": "L'entrée n'a pas pu être trouvée.",
+        "type": {
+          "document": "Document",
+          "note": "Note"
+        },
+        "designation": "Titre",
+        "description": "Notes",
+        "category": "Catégorie",
+        "visibility": "Visibilité",
+        "for-teacher-class-teacher-only": "Seul professeur principal",
+        "for-teacher-all": "Tous les professeurs de la classe",
+        "for-student": "Visible pour {{ studentName }}",
+        "optional": "optionnel",
+        "cancel": "Annuler",
+        "save": "Appliquer",
+        "save-success": "L'entrée a été enregistrée",
+        "save-error": "L'entrée n'a pas pu être enregistrée"
+      }
     }
   },
   "import": {

--- a/src/settings.example.js
+++ b/src/settings.example.js
@@ -254,9 +254,16 @@ window.schulverwaltung.settings = {
   /**
    *  Dossier
    */
+  // Type ID for new entries
+  dossierCreateTypeId: 1052,
+
   // Type ID of additional informations entries created from emails
   // (which include .eml file in attachment)
   dossierEntryEmailTypeId: 1055,
+
+  // Type ID the available AdditionalInformationCodes must have, to be included
+  // in the categories select of the entry creation/update form
+  dossierCategoriesTypeId: 1011,
 
   // Code ID of the additional information entries of type "important information".
   // Those entries are displayed in the student dossier's information header.
@@ -265,4 +272,14 @@ window.schulverwaltung.settings = {
   // Code ID of the additional information entries of type "disadvantage compensation".
   // Those entries are displayed in the student dossier's information header.
   dossierDisadvantageCompensationCodeId: 2000283,
+
+  // Content types of the files the user is allowed to upload
+  dossierAllowedFileTypes: [
+    "application/pdf", // .pdf
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+    "image/png", // .png
+  ],
+
+  // Maximum file size for files of dossier document entries in bytes
+  dossierMaxFileSize: 10 * 1024 * 1024, // 10 MB
 };

--- a/src/spec-helpers.ts
+++ b/src/spec-helpers.ts
@@ -107,9 +107,17 @@ export const settings: Settings = {
     substitutionsAdminLink: "link-to-substitutions-admin-module",
   },
   preventStudentAbsenceAfterLessonStart: ["BsTest"],
+  dossierCreateTypeId: 1052,
   dossierEntryEmailTypeId: 1055,
+  dossierCategoriesTypeId: 1011,
   dossierImportantInformationCodeId: 2000274,
   dossierDisadvantageCompensationCodeId: 2000283,
+  dossierAllowedFileTypes: [
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "image/png",
+  ],
+  dossierMaxFileSize: 50 * 1024 * 1024,
 };
 
 const baseTestModuleMetadata: TestModuleMetadata = {


### PR DESCRIPTION
#925

Zusammen mit https://github.com/bkd-mba-fbi/evento-portal/pull/292 mergen.

- [x] Add Button
- [x] Route/Komponente erstellen
- [x] Formular mit Validierung
- [x] Validierung Max File Size (Settings Eintrag)
- [x] Speichern des Notiz-Eintrags, Toast, zurück auf Dossier
- [x] Speichern des Dokument-Eintrags inkl. File-Upload
- [x] Fehlerbehandlung (Error Responses)
- [x] Tests
- [x] Design/UX Anzeige Lehrpersonen/Lernende

Hinweis: Aktuell funktioniert das Erstellen eines Eintrags vom Type «Dokument» vom Backend her noch nicht. Der Eintrag kann zwar erstellt werden und das File wird hochgeladen, aber `CodeId`, `Description` und `ForStudent` werden nicht übernommen. Deshalb wird der Eintrag dann aktuell nicht in der Liste angezeigt. Sandro hat einen Bug bei SLH eröffnet.