### PR TITLE
Edit dossier entry

### DIFF
--- a/src/app/my-dossier/components/my-dossier/my-dossier.component.html
+++ b/src/app/my-dossier/components/my-dossier/my-dossier.component.html
@@ -5,5 +5,5 @@
       [readonly]="true"
     ></bkd-student-dossier-actions>
   </div>
-  <bkd-student-dossier [readonly]="true"></bkd-student-dossier>
+  <bkd-student-dossier></bkd-student-dossier>
 </div>

--- a/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.html
+++ b/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.html
@@ -1,0 +1,32 @@
+<div class="modal-body">
+  <p data-testid="confirmation-message">
+    @if (type === "document") {
+      {{ "student.dossier.delete.confirm-document" | translate }}
+    } @else {
+      {{ "student.dossier.delete.confirm-note" | translate }}
+    }
+  </p>
+</div>
+<div class="modal-footer">
+  <button
+    data-testid="cancel-button"
+    type="button"
+    class="btn btn-outline-secondary"
+    (click)="activeModal.dismiss()"
+  >
+    <span class="px-2">
+      {{ "student.dossier.delete.no" | translate }}
+    </span>
+  </button>
+
+  <button
+    data-testid="confirm-button"
+    type="button"
+    class="btn btn-primary"
+    (click)="activeModal.close(true)"
+  >
+    <span class="px-3">
+      {{ "student.dossier.delete.yes" | translate }}
+    </span>
+  </button>
+</div>

--- a/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { StudentDossierDeleteDialogComponent } from "./student-dossier-delete-dialog.component";
+
+describe("StudentDossierDeleteComponent", () => {
+  let component: StudentDossierDeleteDialogComponent;
+  let fixture: ComponentFixture<StudentDossierDeleteDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [StudentDossierDeleteDialogComponent],
+        providers: [NgbActiveModal],
+      }),
+    ).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StudentDossierDeleteDialogComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.ts
+++ b/src/app/shared/components/student/student-dossier-delete-dialog/student-dossier-delete-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input, inject } from "@angular/core";
+import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
+import { TranslatePipe } from "@ngx-translate/core";
+
+@Component({
+  selector: "bkd-student-dossier-delete-dialog",
+  templateUrl: "./student-dossier-delete-dialog.component.html",
+  styleUrls: ["./student-dossier-delete-dialog.component.scss"],
+  imports: [TranslatePipe],
+})
+export class StudentDossierDeleteDialogComponent {
+  activeModal = inject(NgbActiveModal);
+
+  @Input() type: "document" | "note";
+}

--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.html
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.html
@@ -1,0 +1,5 @@
+@if (entry().isOwner) {
+  <a [routerLink]="['edit', entry().id]" class="btn btn-icon"
+    ><i class="material-icons">edit</i></a
+  >
+}

--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.scss
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.scss
@@ -1,0 +1,12 @@
+@import "src/bootstrap-variables";
+
+.btn {
+  color: rgba($body-color, 0.5);
+  text-decoration: none;
+}
+
+.btn:hover,
+.btn:active,
+.btn:focus {
+  color: rgba($body-color, 1);
+}

--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { StudentDossierEntry } from "src/app/shared/services/student-dossier.service";
+import { buildAdditionalInformation } from "src/spec-builders";
+import { buildTestModuleMetadata } from "src/spec-helpers";
+import { StudentDossierEditLinkComponent } from "./student-dossier-edit-link.component";
+
+describe("StudentDossierEditLinkComponent", () => {
+  let fixture: ComponentFixture<StudentDossierEditLinkComponent>;
+  let element: HTMLElement;
+  let entry: StudentDossierEntry;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(
+      buildTestModuleMetadata({
+        imports: [StudentDossierEditLinkComponent],
+      }),
+    ).compileComponents();
+
+    fixture = TestBed.createComponent(StudentDossierEditLinkComponent);
+    element = fixture.debugElement.nativeElement;
+    entry = {
+      id: 1,
+      type: "dossier",
+      additionalInformation: buildAdditionalInformation(),
+      category: "2000267",
+      isOwner: true,
+    };
+    fixture.componentRef.setInput("entry", entry);
+    fixture.detectChanges();
+  });
+
+  it("shows edit link if is owner", () => {
+    expect(element.querySelector("a")).not.toBeNull();
+  });
+
+  it("does not show edit link if is not owner", () => {
+    fixture.componentRef.setInput("entry", { ...entry, isOwner: false });
+    fixture.detectChanges();
+    expect(element.querySelector("a")).toBeNull();
+  });
+});

--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.ts
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { StudentDossierEntry } from "src/app/shared/services/student-dossier.service";
+
+@Component({
+  selector: "bkd-student-dossier-edit-link",
+  imports: [RouterLink],
+  templateUrl: "./student-dossier-edit-link.component.html",
+  styleUrl: "./student-dossier-edit-link.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StudentDossierEditLinkComponent {
+  entry = input.required<StudentDossierEntry>();
+}

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
@@ -8,7 +8,14 @@
   } @else if (additionalInformationId() && !info) {
     <h1>{{ "student.dossier.edit.not-found" | translate }}</h1>
   } @else {
-    <h1>{{ heading() }}</h1>
+    <div class="d-flex align-items-center gap-2 mb-4">
+      <h1 class="flex-grow-1 mb-0">{{ heading() }}</h1>
+      @if (additionalInformationId()) {
+        <button class="btn btn-icon btn-outline-secondary" (click)="delete()">
+          <i class="material-icons">delete</i>
+        </button>
+      }
+    </div>
 
     <form (submit)="onSubmit($event)" novalidate>
       @if (!info) {

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.html
@@ -11,19 +11,21 @@
     <h1>{{ heading() }}</h1>
 
     <form (submit)="onSubmit($event)" novalidate>
-      <div class="mb-3">
-        <bkd-button-group
-          [class.is-invalid]="submitted() && entryForm.type().invalid()"
-          [options]="types"
-          [formField]="entryForm.type"
-        ></bkd-button-group>
-        <bkd-form-errors
-          [field]="entryForm.type()"
-          [submitted]="submitted()"
-        ></bkd-form-errors>
-      </div>
+      @if (!info) {
+        <div class="mb-3">
+          <bkd-button-group
+            [class.is-invalid]="submitted() && entryForm.type().invalid()"
+            [options]="types"
+            [formField]="entryForm.type"
+          ></bkd-button-group>
+          <bkd-form-errors
+            [field]="entryForm.type()"
+            [submitted]="submitted()"
+          ></bkd-form-errors>
+        </div>
+      }
 
-      @if (entryForm.type().value() === "document") {
+      @if (entryForm.type().value() === "document" && !info) {
         <div class="mb-3">
           <bkd-file-input
             [acceptedFileTypes]="acceptedFileTypes"

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.scss
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.scss
@@ -1,0 +1,3 @@
+h1 {
+  hyphens: auto;
+}

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
@@ -89,6 +89,19 @@ describe("StudentDossierEditComponent", () => {
       });
     });
 
+    describe("form", () => {
+      it("prefills form with default values", () => {
+        const form = component.entryForm;
+        expect(form.type().value()).toBe("document");
+        expect(form.file().value()).toBeNull();
+        expect(form.designation().value()).toBe("");
+        expect(form.description().value()).toBe("");
+        expect(form.category().value()).toBeNull();
+        expect(form.forTeacher().value()).toBe("class-teacher-only");
+        expect(form.forStudent().value()).toBe(true);
+      });
+    });
+
     describe("onSubmit", () => {
       it("does nothing if form is invalid", async () => {
         await component.onSubmit(new Event("submit"));
@@ -204,7 +217,14 @@ describe("StudentDossierEditComponent", () => {
   describe("edit existing entry", () => {
     let additionalInformation: AdditionalInformation;
     beforeEach(async () => {
-      additionalInformation = buildAdditionalInformation();
+      additionalInformation = {
+        ...buildAdditionalInformation(),
+        ObjectId: 42,
+        ObjectTypeId: 2,
+        TypeId: 1052,
+        Description: "Some description",
+        CodeId: 2000273,
+      };
       additionalInformationId$.next(additionalInformation.Id);
       additionalInformation$.next(additionalInformation);
       fixture.detectChanges();
@@ -214,6 +234,35 @@ describe("StudentDossierEditComponent", () => {
     describe("heading", () => {
       it("returns the heading for an existing entry", () => {
         expect(component.heading()).toBe("student.dossier.edit.title-update");
+      });
+    });
+
+    describe("form", () => {
+      it("prefills form with existing note entry data", () => {
+        const form = component.entryForm;
+        expect(form.type().value()).toBe("note");
+        expect(form.designation().value()).toBe("Lorem ipsum");
+        expect(form.description().value()).toBe("Some description");
+        expect(form.category().value()).toBe(2000273);
+        expect(form.forTeacher().value()).toBe("class-teacher-only");
+        expect(form.forStudent().value()).toBe(false);
+      });
+
+      it("prefills form with existing document entry data", () => {
+        additionalInformation.ObjectId = 12345;
+        additionalInformation.ObjectTypeId = 3;
+        additionalInformation.File = "/path/to/file.pdf";
+        additionalInformation.ForStudent = true;
+        additionalInformation$.next({ ...additionalInformation });
+        fixture.detectChanges();
+
+        const form = component.entryForm;
+        expect(form.type().value()).toBe("document");
+        expect(form.designation().value()).toBe("Lorem ipsum");
+        expect(form.description().value()).toBe("Some description");
+        expect(form.category().value()).toBe(2000273);
+        expect(form.forTeacher().value()).toBe("all");
+        expect(form.forStudent().value()).toBe(true);
       });
     });
 
@@ -227,7 +276,117 @@ describe("StudentDossierEditComponent", () => {
         expect(toastService.success).not.toHaveBeenCalled();
       });
 
-      // TODO: Add update tests in #929
+      describe("note", () => {
+        it("saves the entry for class teacher only", async () => {
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "note",
+            {
+              Id: 1,
+              ObjectId: 42,
+              ObjectTypeId: 2,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: "Some description",
+              ForStudent: false,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+
+        it("saves the entry for all teachers", async () => {
+          component.entryForm.type().value.set("note");
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          component.entryForm.forTeacher().value.set("all");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "note",
+            {
+              Id: 1,
+              ObjectId: 42,
+              ObjectTypeId: 3,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: "Some description",
+              ForStudent: false,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+      });
+
+      describe("document", () => {
+        beforeEach(() => {
+          additionalInformation.File = "/path/to/file.pdf";
+          additionalInformation$.next({ ...additionalInformation });
+          fixture.detectChanges();
+        });
+
+        it("saves the entry for class teacher only", async () => {
+          component.entryForm.type().value.set("document");
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "document",
+            {
+              Id: 1,
+              ObjectId: 42,
+              ObjectTypeId: 2,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: "Some description",
+              ForStudent: false,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+
+        it("saves the entry for all teachers", async () => {
+          additionalInformation.ObjectId = 12345;
+          additionalInformation.ObjectTypeId = 3;
+          additionalInformation$.next({ ...additionalInformation });
+          fixture.detectChanges();
+
+          component.entryForm.type().value.set("document");
+          component.entryForm.designation().value.set("Anruf Eltern");
+          component.entryForm.category().value.set("2000267");
+          component.entryForm.forTeacher().value.set("all");
+          fixture.detectChanges();
+
+          await component.onSubmit(new Event("submit"));
+          expect(editService.save).toHaveBeenCalledWith(
+            "document",
+            {
+              Id: 1,
+              ObjectId: 12345,
+              ObjectTypeId: 3,
+              TypeId: 1052,
+              CodeId: 2000267,
+              Designation: "Anruf Eltern",
+              Description: "Some description",
+              ForStudent: false,
+            },
+            null,
+          );
+          expect(toastService.success).toHaveBeenCalled();
+        });
+      });
     });
   });
 });

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router } from "@angular/router";
+import { NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 import { BehaviorSubject, of } from "rxjs";
 import { AdditionalInformation } from "src/app/shared/models/additional-informations.model";
+import { BkdModalService } from "src/app/shared/services/bkd-modal.service";
 import { StudentDossierEditService } from "src/app/shared/services/student-dossier-edit.service";
 import { ToastService } from "src/app/shared/services/toast.service";
 import { buildAdditionalInformation } from "src/spec-builders";
@@ -13,6 +15,7 @@ describe("StudentDossierEditComponent", () => {
   let fixture: ComponentFixture<StudentDossierEditComponent>;
   let editService: jasmine.SpyObj<StudentDossierEditService>;
   let toastService: jasmine.SpyObj<ToastService>;
+  let modalService: jasmine.SpyObj<BkdModalService>;
   let router: jasmine.SpyObj<Router>;
   let additionalInformationId$: BehaviorSubject<Option<number>>;
   let additionalInformation$: BehaviorSubject<Option<AdditionalInformation>>;
@@ -24,7 +27,7 @@ describe("StudentDossierEditComponent", () => {
     );
     editService = jasmine.createSpyObj(
       "StudentDossierEditService",
-      ["getSubscriptionId", "save"],
+      ["getSubscriptionId", "save", "delete"],
       {
         loading$: of(false),
         studentId$: of(42),
@@ -49,8 +52,10 @@ describe("StudentDossierEditComponent", () => {
     );
     editService.getSubscriptionId.and.returnValue(Promise.resolve(10));
     editService.save.and.returnValue(Promise.resolve());
+    editService.delete.and.returnValue(Promise.resolve());
 
     toastService = jasmine.createSpyObj("ToastService", ["success"]);
+    modalService = jasmine.createSpyObj("BkdModalService", ["open"]);
     router = jasmine.createSpyObj("Router", ["navigate"]);
 
     await TestBed.configureTestingModule(
@@ -58,6 +63,7 @@ describe("StudentDossierEditComponent", () => {
         imports: [StudentDossierEditComponent],
         providers: [
           { provide: ToastService, useValue: toastService },
+          { provide: BkdModalService, useValue: modalService },
           { provide: Router, useValue: router },
           { provide: ActivatedRoute, useValue: {} },
         ],
@@ -386,6 +392,29 @@ describe("StudentDossierEditComponent", () => {
           );
           expect(toastService.success).toHaveBeenCalled();
         });
+      });
+    });
+
+    describe("delete", () => {
+      it("opens confirmation dialog and deletes entry when confirmed", async () => {
+        const modalRef = {
+          componentInstance: {},
+          result: Promise.resolve(true),
+        } as NgbModalRef;
+        modalService.open.and.returnValue(modalRef);
+
+        await component.delete();
+
+        expect(modalService.open).toHaveBeenCalled();
+        expect(modalRef.componentInstance.type).toBe("note");
+
+        await modalRef.result;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(editService.delete).toHaveBeenCalledWith(
+          additionalInformation.Id,
+        );
+        expect(toastService.success).toHaveBeenCalled();
       });
     });
   });

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
@@ -3,10 +3,11 @@ import {
   Component,
   computed,
   inject,
+  linkedSignal,
   signal,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { FormField, form, required } from "@angular/forms/signals";
+import { FormField, disabled, form, required } from "@angular/forms/signals";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { SETTINGS, Settings } from "src/app/settings";
@@ -98,32 +99,42 @@ export class StudentDossierEditComponent {
     label: this.translate.instant(`student.dossier.edit.type.${key}`),
   }));
 
-  entryFormData = signal<DossierEntryFormData>({
-    type: "document",
-    file: null,
-    designation: "",
-    description: "",
-    category: null,
-    forTeacher: "class-teacher-only",
-    forStudent: true,
+  entryFormData = linkedSignal<DossierEntryFormData>(() => {
+    const info = this.additionalInformation();
+    return {
+      type: info ? (info.File ? "document" : "note") : "document",
+      file: null,
+      designation: info?.Designation ?? "",
+      description: info?.Description ?? "",
+      category: info?.CodeId ?? null,
+      forTeacher: info
+        ? info.ObjectTypeId === CLASS_TEACHER_OBJECT_TYPE_ID
+          ? "class-teacher-only"
+          : "all"
+        : "class-teacher-only",
+      forStudent: info?.ForStudent ?? true,
+    };
   });
   entryForm = form(this.entryFormData, (schema) => {
+    const editing = () => Boolean(this.additionalInformation());
     const isDocument = () => this.entryFormData().type === "document";
+    const hasFile = () => isDocument() && !editing();
     required(schema.type);
     required(schema.file, {
-      when: isDocument,
+      when: hasFile,
     });
     maxFileSize(schema.file, {
       maxBytes: this.settings.dossierMaxFileSize,
-      when: isDocument,
+      when: hasFile,
     });
     fileType(schema.file, {
       acceptedFileTypes: this.acceptedFileTypes,
-      when: isDocument,
+      when: hasFile,
     });
     required(schema.designation);
     required(schema.category);
     required(schema.forTeacher);
+    disabled(schema.forTeacher, editing);
   });
 
   submitted = signal(false);
@@ -163,11 +174,13 @@ export class StudentDossierEditComponent {
     studentId: Option<number>,
     formData: DossierEntryFormData,
   ): Promise<Partial<AdditionalInformation>> {
+    const info = this.additionalInformation();
     const { designation, description, category, forTeacher, forStudent } =
       formData;
 
-    return {
-      ObjectId: await this.getObjectId(studentId, forTeacher),
+    const entry: Partial<AdditionalInformation> = {
+      ObjectId:
+        info?.ObjectId ?? (await this.getObjectId(studentId, forTeacher)),
       ObjectTypeId:
         forTeacher === "class-teacher-only"
           ? CLASS_TEACHER_OBJECT_TYPE_ID
@@ -178,6 +191,12 @@ export class StudentDossierEditComponent {
       Description: description?.trim() || null,
       ForStudent: forStudent,
     };
+
+    if (info?.Id) {
+      entry.Id = info?.Id;
+    }
+
+    return entry;
   }
 
   /**

--- a/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
+++ b/src/app/shared/components/student/student-dossier-edit/student-dossier-edit.component.ts
@@ -13,6 +13,7 @@ import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { SETTINGS, Settings } from "src/app/settings";
 import { AdditionalInformation } from "src/app/shared/models/additional-informations.model";
 import { DropDownItem } from "src/app/shared/models/drop-down-item.model";
+import { BkdModalService } from "src/app/shared/services/bkd-modal.service";
 import { StudentDossierEditService } from "src/app/shared/services/student-dossier-edit.service";
 import { ToastService } from "src/app/shared/services/toast.service";
 import { fileType } from "src/app/shared/validators/file-type.validator";
@@ -24,6 +25,7 @@ import { FormErrorsComponent } from "../../form-errors/form-errors.component";
 import { SelectComponent } from "../../select/select.component";
 import { SpinnerComponent } from "../../spinner/spinner.component";
 import { SubmitButtonComponent } from "../../submit-button/submit-button.component";
+import { StudentDossierDeleteDialogComponent } from "../student-dossier-delete-dialog/student-dossier-delete-dialog.component";
 
 type DossierEntryFormData = {
   type: "document" | "note";
@@ -63,6 +65,7 @@ export class StudentDossierEditComponent {
   private translate = inject(TranslateService);
   private editService = inject(StudentDossierEditService);
   private toastService = inject(ToastService);
+  private modalService = inject(BkdModalService);
   private settings = inject<Settings>(SETTINGS);
 
   acceptedFileTypes = this.settings.dossierAllowedFileTypes;
@@ -138,6 +141,40 @@ export class StudentDossierEditComponent {
   });
 
   submitted = signal(false);
+
+  async delete() {
+    const info = this.additionalInformation();
+    const id = info?.Id;
+    if (!info || !id) {
+      return;
+    }
+
+    const modalRef = this.modalService.open(
+      StudentDossierDeleteDialogComponent,
+    );
+    modalRef.componentInstance.type = info.File ? "document" : "note";
+
+    let result = false;
+    try {
+      result = await modalRef.result;
+    } catch {
+      result = false;
+    }
+
+    if (result) {
+      const success = await this.deleteEntry(id);
+      if (success) {
+        this.toastService.success(
+          this.translate.instant("student.dossier.delete.delete-success"),
+        );
+        await this.navigateBack();
+      } else {
+        this.toastService.error(
+          this.translate.instant("student.dossier.delete.delete-error"),
+        );
+      }
+    }
+  }
 
   async onSubmit(event: Event) {
     event.preventDefault();
@@ -234,6 +271,16 @@ export class StudentDossierEditComponent {
       return true;
     } catch (error) {
       console.error("Failed to save entry:", error);
+      return false;
+    }
+  }
+
+  private async deleteEntry(id: number): Promise<boolean> {
+    try {
+      await this.editService.delete(id);
+      return true;
+    } catch (error) {
+      console.error("Failed to delete entry:", error);
       return false;
     }
   }

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
@@ -13,7 +13,12 @@
   </div>
 }
 
-<div class="info">
-  {{ "student.dossier.created" | translate }}:
-  {{ info.CreationDate | date: "dd.MM.yyyy" }}
+<div class="footer">
+  <div class="info">
+    {{ "student.dossier.created" | translate }}:
+    {{ info.CreationDate | date: "dd.MM.yyyy" }}
+  </div>
+  <bkd-student-dossier-edit-link
+    [entry]="entry()"
+  ></bkd-student-dossier-edit-link>
 </div>

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.scss
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.scss
@@ -13,3 +13,9 @@
   font-weight: 400;
   line-height: 1.5;
 }
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
@@ -54,7 +54,7 @@ describe("StudentDossierEntryBodyComponent", () => {
 
   describe("document link", () => {
     it("does not render a link if no file is available", () => {
-      expect(element.querySelector("a")).toBeNull();
+      expect(element.querySelector("a:not(.btn)")).toBeNull();
     });
 
     it("renders a link if a file is available", () => {
@@ -62,7 +62,7 @@ describe("StudentDossierEntryBodyComponent", () => {
         "/restApi/Files/AdditionalInformation/1015/File";
       fixture.componentRef.setInput("entry", { ...entry });
       fixture.detectChanges();
-      const link = element.querySelector("a");
+      const link = element.querySelector<HTMLAnchorElement>("a:not(.btn)");
       expect(link).not.toBeNull();
       expect(link?.href).toBe(
         "https://eventotest.api/Files/AdditionalInformation/1015/File?token=ey...",

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.ts
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.ts
@@ -10,11 +10,17 @@ import { TranslatePipe } from "@ngx-translate/core";
 import { SETTINGS, Settings } from "src/app/settings";
 import { StorageService } from "src/app/shared/services/storage.service";
 import { StudentDossierEntry } from "src/app/shared/services/student-dossier.service";
+import { StudentDossierEditLinkComponent } from "../student-dossier-edit-link/student-dossier-edit-link.component";
 import { StudentDossierEntryDescriptionComponent } from "../student-dossier-entry-description/student-dossier-entry-description.component";
 
 @Component({
   selector: "bkd-student-dossier-entry-body",
-  imports: [StudentDossierEntryDescriptionComponent, DatePipe, TranslatePipe],
+  imports: [
+    StudentDossierEntryDescriptionComponent,
+    StudentDossierEditLinkComponent,
+    DatePipe,
+    TranslatePipe,
+  ],
   templateUrl: "./student-dossier-entry-body.component.html",
   styleUrl: "./student-dossier-entry-body.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/components/student/student-dossier-information/student-dossier-information.component.html
+++ b/src/app/shared/components/student/student-dossier-information/student-dossier-information.component.html
@@ -12,20 +12,30 @@
     <div ngbAccordionBody>
       <ng-template>
         @for (entry of informationEntries(); track entry.id) {
-          <div>
-            <h6>{{ entry.additionalInformation.Designation }}</h6>
-            <bkd-student-dossier-entry-description
+          <div class="d-flex">
+            <div class="flex-grow-1">
+              <h6>{{ entry.additionalInformation.Designation }}</h6>
+              <bkd-student-dossier-entry-description
+                [entry]="entry"
+              ></bkd-student-dossier-entry-description>
+            </div>
+            <bkd-student-dossier-edit-link
               [entry]="entry"
-            ></bkd-student-dossier-entry-description>
+            ></bkd-student-dossier-edit-link>
           </div>
         }
         @for (entry of disadvantageEntries(); track entry.id) {
-          <div>
-            <h6>{{ "student.dossier.disadvantage" | translate }}</h6>
-            {{ entry.additionalInformation.Designation }}
-            <bkd-student-dossier-entry-description
+          <div class="d-flex">
+            <div class="flex-grow-1">
+              <h6>{{ "student.dossier.disadvantage" | translate }}</h6>
+              {{ entry.additionalInformation.Designation }}
+              <bkd-student-dossier-entry-description
+                [entry]="entry"
+              ></bkd-student-dossier-entry-description>
+            </div>
+            <bkd-student-dossier-edit-link
               [entry]="entry"
-            ></bkd-student-dossier-entry-description>
+            ></bkd-student-dossier-edit-link>
           </div>
         }
       </ng-template>

--- a/src/app/shared/components/student/student-dossier-information/student-dossier-information.component.ts
+++ b/src/app/shared/components/student/student-dossier-information/student-dossier-information.component.ts
@@ -7,6 +7,7 @@ import {
 } from "@ng-bootstrap/ng-bootstrap";
 import { TranslatePipe } from "@ngx-translate/core";
 import { StudentDossierEntry } from "src/app/shared/services/student-dossier.service";
+import { StudentDossierEditLinkComponent } from "../student-dossier-edit-link/student-dossier-edit-link.component";
 import { StudentDossierEntryDescriptionComponent } from "../student-dossier-entry-description/student-dossier-entry-description.component";
 import { StudentDossierEntryHeaderComponent } from "../student-dossier-entry-header/student-dossier-entry-header.component";
 
@@ -20,6 +21,7 @@ import { StudentDossierEntryHeaderComponent } from "../student-dossier-entry-hea
     TranslatePipe,
     StudentDossierEntryHeaderComponent,
     StudentDossierEntryDescriptionComponent,
+    StudentDossierEditLinkComponent,
   ],
   templateUrl: "./student-dossier-information.component.html",
   styleUrl: "./student-dossier-information.component.scss",

--- a/src/app/shared/components/student/student-dossier/student-dossier.component.ts
+++ b/src/app/shared/components/student/student-dossier/student-dossier.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  inject,
-  input,
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { NgbAccordionDirective } from "@ng-bootstrap/ng-bootstrap";
 import { TranslatePipe } from "@ngx-translate/core";
@@ -28,8 +23,6 @@ import { StudentDossierInformationComponent } from "../student-dossier-informati
 })
 export class StudentDossierComponent {
   dossierService = inject(StudentDossierService);
-
-  readonly = input<boolean>(false);
 
   loading = toSignal(this.dossierService.loading$, { requireSync: true });
   informationEntries = toSignal(this.dossierService.informationEntries$, {

--- a/src/app/shared/services/additional-informations-rest.service.ts
+++ b/src/app/shared/services/additional-informations-rest.service.ts
@@ -49,6 +49,15 @@ export class AdditionalInformationsRestService extends RestService<
   }
 
   /**
+   * Deletes an AdditionalInformation entry.
+   */
+  delete(id: number): Observable<void> {
+    return this.http
+      .delete(`${this.settings.apiUrl}/AdditionalInformations/${id}`)
+      .pipe(map(() => undefined));
+  }
+
+  /**
    * Creates an AdditionalInformation entry with an associated file (two
    * requests). Error responses are not handled by the interceptor and must be
    * handled by the consumer.

--- a/src/app/shared/services/additional-informations-rest.service.ts
+++ b/src/app/shared/services/additional-informations-rest.service.ts
@@ -32,6 +32,23 @@ export class AdditionalInformationsRestService extends RestService<
   }
 
   /**
+   * Updates an AdditionalInformation entry.
+   */
+  update(
+    entry: Pick<AdditionalInformation, "Id"> &
+      Partial<Omit<AdditionalInformation, "Id">>,
+    options: { context?: HttpContext } = {},
+  ): Observable<void> {
+    return this.http
+      .put(
+        `${this.settings.apiUrl}/AdditionalInformations/${entry.Id}`,
+        entry,
+        options,
+      )
+      .pipe(map(() => undefined));
+  }
+
+  /**
    * Creates an AdditionalInformation entry with an associated file (two
    * requests). Error responses are not handled by the interceptor and must be
    * handled by the consumer.

--- a/src/app/shared/services/student-dossier-edit.service.spec.ts
+++ b/src/app/shared/services/student-dossier-edit.service.spec.ts
@@ -54,13 +54,14 @@ describe("StudentDossierEditService", () => {
     additionalInformationsService =
       jasmine.createSpyObj<AdditionalInformationsRestService>(
         "AdditionalInformationsRestService",
-        ["get", "create", "createWithFile"],
+        ["get", "create", "update", "createWithFile"],
       );
     additionalInformation = buildAdditionalInformation();
     additionalInformationsService.get.and.returnValue(
       of(additionalInformation),
     );
     additionalInformationsService.create.and.returnValue(of(undefined));
+    additionalInformationsService.update.and.returnValue(of(undefined));
     additionalInformationsService.createWithFile.and.returnValue(of(undefined));
 
     dropDownItemsService = jasmine.createSpyObj<DropDownItemsRestService>(
@@ -213,36 +214,96 @@ describe("StudentDossierEditService", () => {
 
   describe("save", () => {
     describe("note", () => {
-      it("creates an entry", async () => {
-        await service.save("note", additionalInformation, null);
-        expect(additionalInformationsService.create).toHaveBeenCalledWith(
-          additionalInformation,
-          jasmine.any(Object),
-        );
-        expect(
-          additionalInformationsService.createWithFile,
-        ).not.toHaveBeenCalled();
+      describe("new entry", () => {
+        it("creates an entry", async () => {
+          const entry = additionalInformation as Partial<AdditionalInformation>;
+          delete entry.Id;
+          await service.save("note", entry, null);
+          expect(additionalInformationsService.create).toHaveBeenCalledWith(
+            entry,
+            jasmine.any(Object),
+          );
+          expect(
+            additionalInformationsService.createWithFile,
+          ).not.toHaveBeenCalled();
+        });
+      });
+
+      describe("existing entry", () => {
+        it("updates an entry", async () => {
+          const entry = additionalInformation;
+          await service.save("note", entry, null);
+          expect(additionalInformationsService.update).toHaveBeenCalledWith(
+            entry,
+            jasmine.any(Object),
+          );
+          expect(
+            additionalInformationsService.createWithFile,
+          ).not.toHaveBeenCalled();
+        });
       });
     });
 
     describe("document", () => {
-      it("creates a file entry", async () => {
-        const file = new File([], "test.pdf");
-        await service.save("document", additionalInformation, file);
-        expect(
-          additionalInformationsService.createWithFile,
-        ).toHaveBeenCalledWith(additionalInformation, file, "test.pdf");
-        expect(additionalInformationsService.create).not.toHaveBeenCalled();
+      describe("new entry", () => {
+        it("creates a file entry", async () => {
+          const entry = additionalInformation as Partial<AdditionalInformation>;
+          delete entry.Id;
+          const file = new File([], "test.pdf");
+          await service.save("document", entry, file);
+          expect(
+            additionalInformationsService.createWithFile,
+          ).toHaveBeenCalledWith(entry, file, "test.pdf");
+          expect(additionalInformationsService.create).not.toHaveBeenCalled();
+        });
+
+        it("throws an error if file is not present", async () => {
+          const entry = additionalInformation as Partial<AdditionalInformation>;
+          delete entry.Id;
+          await expectAsync(
+            service.save("document", entry, null),
+          ).toBeRejectedWithError("File is not present");
+          expect(
+            additionalInformationsService.createWithFile,
+          ).not.toHaveBeenCalled();
+          expect(additionalInformationsService.create).not.toHaveBeenCalled();
+        });
       });
 
-      it("throws an error if file is not present", async () => {
-        await expectAsync(
-          service.save("document", additionalInformation, null),
-        ).toBeRejectedWithError("File is not present");
-        expect(
-          additionalInformationsService.createWithFile,
-        ).not.toHaveBeenCalled();
-        expect(additionalInformationsService.create).not.toHaveBeenCalled();
+      describe("existing entry", () => {
+        it("updates entry, but without the file field", async () => {
+          const entry = additionalInformation as Pick<
+            AdditionalInformation,
+            "Id"
+          > &
+            Partial<Omit<AdditionalInformation, "Id">>;
+          await service.save("document", entry, null);
+          expect(additionalInformationsService.update).toHaveBeenCalledWith(
+            entry,
+            jasmine.any(Object),
+          );
+          expect(additionalInformationsService.create).not.toHaveBeenCalled();
+          expect(
+            additionalInformationsService.createWithFile,
+          ).not.toHaveBeenCalled();
+        });
+
+        it("throws an error if file is present", async () => {
+          const entry = additionalInformation as Pick<
+            AdditionalInformation,
+            "Id"
+          > &
+            Partial<Omit<AdditionalInformation, "Id">>;
+          const file = new File([], "test.pdf");
+          await expectAsync(
+            service.save("document", entry, file),
+          ).toBeRejectedWithError("File update is not supported");
+          expect(additionalInformationsService.update).not.toHaveBeenCalled();
+          expect(additionalInformationsService.create).not.toHaveBeenCalled();
+          expect(
+            additionalInformationsService.createWithFile,
+          ).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/src/app/shared/services/student-dossier-edit.service.spec.ts
+++ b/src/app/shared/services/student-dossier-edit.service.spec.ts
@@ -54,7 +54,7 @@ describe("StudentDossierEditService", () => {
     additionalInformationsService =
       jasmine.createSpyObj<AdditionalInformationsRestService>(
         "AdditionalInformationsRestService",
-        ["get", "create", "update", "createWithFile"],
+        ["get", "create", "update", "delete", "createWithFile"],
       );
     additionalInformation = buildAdditionalInformation();
     additionalInformationsService.get.and.returnValue(
@@ -62,6 +62,7 @@ describe("StudentDossierEditService", () => {
     );
     additionalInformationsService.create.and.returnValue(of(undefined));
     additionalInformationsService.update.and.returnValue(of(undefined));
+    additionalInformationsService.delete.and.returnValue(of(undefined));
     additionalInformationsService.createWithFile.and.returnValue(of(undefined));
 
     dropDownItemsService = jasmine.createSpyObj<DropDownItemsRestService>(
@@ -305,6 +306,13 @@ describe("StudentDossierEditService", () => {
           ).not.toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes the entry", async () => {
+      await service.delete(123);
+      expect(additionalInformationsService.delete).toHaveBeenCalledWith(123);
     });
   });
 });

--- a/src/app/shared/services/student-dossier-edit.service.ts
+++ b/src/app/shared/services/student-dossier-edit.service.ts
@@ -82,6 +82,10 @@ export class StudentDossierEditService {
     return this.create(type, entry, file);
   }
 
+  delete(id: number): Promise<void> {
+    return firstValueFrom(this.additionalInformationsService.delete(id));
+  }
+
   private async create(
     type: "document" | "note",
     entry: Partial<AdditionalInformation>,

--- a/src/app/shared/services/student-dossier-edit.service.ts
+++ b/src/app/shared/services/student-dossier-edit.service.ts
@@ -71,6 +71,22 @@ export class StudentDossierEditService {
     entry: Partial<AdditionalInformation>,
     file: Option<File>,
   ): Promise<void> {
+    if (entry.Id) {
+      return this.update(
+        type,
+        entry as Pick<AdditionalInformation, "Id"> &
+          Partial<Omit<AdditionalInformation, "Id">>,
+        file,
+      );
+    }
+    return this.create(type, entry, file);
+  }
+
+  private async create(
+    type: "document" | "note",
+    entry: Partial<AdditionalInformation>,
+    file: Option<File>,
+  ): Promise<void> {
     let save$: Observable<void>;
     switch (type) {
       case "document":
@@ -93,6 +109,27 @@ export class StudentDossierEditService {
       default:
         throw new UnreachableError(type, "Unhandled type");
     }
+    await firstValueFrom(save$);
+  }
+
+  private async update(
+    type: "document" | "note",
+    entry: Pick<AdditionalInformation, "Id"> &
+      Partial<Omit<AdditionalInformation, "Id">>,
+    file: Option<File>,
+  ): Promise<void> {
+    const id = entry.Id;
+    if (!id) {
+      throw new Error("Entry ID is not present");
+    }
+    if (file) {
+      throw new Error("File update is not supported");
+    }
+    const save$ = this.additionalInformationsService.update(entry, {
+      context: new HttpContext().set(RestErrorInterceptorOptions, {
+        disableErrorHandling: true,
+      }),
+    });
     await firstValueFrom(save$);
   }
 

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -465,6 +465,14 @@
         "save": "Übernehmen",
         "save-success": "Der Eintrag wurde gespeichert",
         "save-error": "Der Eintrag konnte nicht gespeichert werden"
+      },
+      "delete": {
+        "confirm-note": "Wollen Sie diesen Eintrag löschen?",
+        "confirm-document": "Wollen Sie diesen Eintrag und das Dokument löschen?",
+        "yes": "Löschen",
+        "no": "Abbrechen",
+        "delete-success": "Der Eintrag wurde gelöscht",
+        "delete-error": "Der Eintrag konnte nicht gelöscht werden"
       }
     }
   },

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -465,6 +465,14 @@
         "save": "Appliquer",
         "save-success": "L'entrée a été enregistrée",
         "save-error": "L'entrée n'a pas pu être enregistrée"
+      },
+      "delete": {
+        "confirm-note": "Voulez-vous supprimer cette entrée ?",
+        "confirm-document": "Voulez-vous supprimer cette entrée et le document ?",
+        "yes": "Supprimer",
+        "no": "Annuler",
+        "delete-success": "L'entrée a été supprimée",
+        "delete-error": "L'entrée n'a pas pu être supprimée"
       }
     }
   },


### PR DESCRIPTION
#929

- [x] Anzeige des Edit-Stifts
  - Bei normalen Einträgen
  - Bei Einträgen unter «Information»
- [x] Bearbeiten von Notizen-Einträgen
- [ ] ~~Bearbeiten der «Anzeige für Lehrpersonen»~~ → Nicht möglich, Option ist disabled.
- [ ] ~~Speichern von Dokument-Einträgen inkl. File Updates~~ → Es ist aktuell nicht möglich das File zu aktualisieren, Dokument-Einträge werden über das normale PUT aktualisiert.
- [x] Einträge löschen
- [x] Testen im «Mein Dossier» → allenfalls `readonly` Input entfernen