### PR TITLE
Dossier File Improvements

### DIFF
--- a/src/app/shared/components/file-input/file-input.component.html
+++ b/src/app/shared/components/file-input/file-input.component.html
@@ -1,5 +1,6 @@
 <label for="formFile" class="form-label">{{
-  "shared.file-input.input-label" | translate
+  "shared.file-input.input-label"
+    | translate: { acceptedExtensions: acceptedFileExtensions().join(", ") }
 }}</label>
 <input
   class="form-control"

--- a/src/app/shared/components/file-input/file-input.component.ts
+++ b/src/app/shared/components/file-input/file-input.component.ts
@@ -4,12 +4,14 @@ import {
   Component,
   ElementRef,
   OnDestroy,
+  computed,
   input,
   model,
   signal,
   viewChild,
 } from "@angular/core";
 import { TranslatePipe } from "@ngx-translate/core";
+import { getExtensionFromMimeType } from "../../utils/mime";
 
 @Component({
   selector: "bkd-file-input",
@@ -25,6 +27,10 @@ export class FileInputComponent implements AfterViewInit, OnDestroy {
   acceptedFileTypes = input.required<ReadonlyArray<string>>();
   error = input<Option<string>>(null);
   value = model<Option<File>>(null);
+
+  acceptedFileExtensions = computed(() =>
+    this.acceptedFileTypes().map(this.getFileExtensionForType.bind(this)),
+  );
 
   dragging = signal(false); // Used to show the drop zone when dragging a file into the viewport
   private dragCount = 0;
@@ -73,5 +79,13 @@ export class FileInputComponent implements AfterViewInit, OnDestroy {
     const input = this.fileInput().nativeElement;
     input.files = event.dataTransfer?.files ?? null;
     input.dispatchEvent(new Event("change"));
+  }
+
+  private getFileExtensionForType(fileType: string): string {
+    if (fileType.startsWith(".")) {
+      return fileType;
+    }
+    const extension = getExtensionFromMimeType(fileType);
+    return extension ? `.${extension}` : fileType;
   }
 }

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
@@ -8,6 +8,7 @@
     <a
       (click)="openDocument()"
       (keydown.enter)="openDocument()"
+      (keyup.space)="openDocument()"
       role="button"
       tabindex="0"
     >

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.html
@@ -2,10 +2,15 @@
   [entry]="entry()"
 ></bkd-student-dossier-entry-description>
 
-@if (documentUrl()) {
+@if (hasDocument()) {
   <div class="document-link">
     <i class="material-icons-outlined">remove_red_eye</i>
-    <a [href]="documentUrl()" target="_blank">
+    <a
+      (click)="openDocument()"
+      (keydown.enter)="openDocument()"
+      role="button"
+      tabindex="0"
+    >
       {{ "student.dossier.download" | translate }}
     </a>
   </div>

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
@@ -118,16 +118,20 @@ describe("StudentDossierEntryBodyComponent", () => {
     });
 
     it("renders a link if a file is available", () => {
+      const windowOpenSpy = spyOn(window, "open");
       entry.additionalInformation.File =
         "/restApi/Files/AdditionalInformation/1015/File";
       fixture.componentRef.setInput("entry", { ...entry });
       fixture.detectChanges();
+
       const link = element.querySelector<HTMLAnchorElement>("a:not(.btn)");
       expect(link).not.toBeNull();
-      expect(link?.href).toBe(
+      link?.click();
+
+      expect(windowOpenSpy).toHaveBeenCalledWith(
         "https://eventotest.api/Files/AdditionalInformation/1015/File?token=ey...",
+        "_blank",
       );
-      expect(link?.target).toBe("_blank");
     });
   });
 });

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.ts
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.ts
@@ -29,11 +29,31 @@ export class StudentDossierEntryBodyComponent {
 
   entry = input.required<StudentDossierEntry>();
 
-  documentUrl = computed(() => {
-    const filePath = this.entry().additionalInformation.File;
-    if (!filePath) {
+  documentPath = computed(
+    () =>
+      // The path in the `File` attribute starts with `/restApi`, so we remove
+      // this to have the actual document path without the API prefix
+      this.entry().additionalInformation.File?.replace(/^\/restApi/, "") ??
+      null,
+  );
+  hasDocument = computed(() => Boolean(this.documentPath()));
+
+  openDocument(): void {
+    // We generate the URL that includes the token when we are using it,
+    // otherwise the token can already be expired (hence this openDocument()
+    // call and no href="" attribute).
+    const url = this.getDocumentUrl();
+    if (url) {
+      window.open(url, "_blank");
+    }
+  }
+
+  private getDocumentUrl(): Option<string> {
+    const documentPath = this.documentPath();
+    if (!documentPath) {
       return null;
     }
-    return `${this.settings.apiUrl}${filePath.replace(/^\/restApi/, "")}?token=${this.storageService.getAccessToken()}`;
-  });
+    const token = this.storageService.getAccessToken();
+    return `${this.settings.apiUrl}${documentPath}?token=${token}`;
+  }
 }

--- a/src/app/shared/utils/mime.spec.ts
+++ b/src/app/shared/utils/mime.spec.ts
@@ -1,0 +1,21 @@
+import { getExtensionFromMimeType } from "./mime";
+
+describe("mime utils", () => {
+  describe("getExtensionFromMimeType", () => {
+    it('returns "pdf" for type "application/pdf"', () => {
+      expect(getExtensionFromMimeType("application/pdf")).toBe("pdf");
+    });
+
+    it('returns "docx" for type "application/vnd.openxmlformats-officedocument.wordprocessingml.document"', () => {
+      expect(
+        getExtensionFromMimeType(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+      ).toBe("docx");
+    });
+
+    it('returns null for unknown type "text/x-gibberish"', () => {
+      expect(getExtensionFromMimeType("text/x-gibberish")).toBeNull();
+    });
+  });
+});

--- a/src/app/shared/utils/mime.ts
+++ b/src/app/shared/utils/mime.ts
@@ -1,0 +1,37 @@
+const mimeTypes: Record<string, string> = {
+  "text/plain": "txt",
+  "application/json": "json",
+  "application/zip": "zip",
+
+  // Documents
+  "application/pdf": "pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/msword": "doc",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/vnd.ms-excel": "xls",
+  "text/csv": "csv",
+
+  // Images
+  "image/png": "png",
+  "image/jpeg": "jpeg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/avif": "avif",
+
+  // Emails
+  "message/rfc822": "eml",
+  "application/vnd.ms-outlook": "msg",
+};
+
+/**
+ * Returns the file extension for the given MIME/content type. The lookup is
+ * based on a very limited set of mime types. Returns null if no entry is found.
+ */
+export function getExtensionFromMimeType(mimeType: string): Option<string> {
+  const extension = mimeTypes[mimeType] ?? null;
+  if (!extension) {
+    console.warn(`File extension for content type "${mimeType}" not found`);
+  }
+  return extension;
+}

--- a/src/app/shared/validators/file-type.validator.spec.ts
+++ b/src/app/shared/validators/file-type.validator.spec.ts
@@ -7,7 +7,7 @@ type Model = {
   file: Option<File>;
 };
 
-const ACCEPTED_FILE_TYPES = ["application/pdf", "image/png"] as const;
+const ACCEPTED_FILE_TYPES = ["application/pdf", "image/png", ".msg"] as const;
 
 describe("fileType", () => {
   let model: WritableSignal<Model>;
@@ -64,6 +64,14 @@ describe("fileType", () => {
     };
     expect(error.kind).toBe("fileType");
     expect(error.message).toContain("not allowed");
+  });
+
+  it("is valid for a (proprietary) file without type that is accepted by file extension", () => {
+    const msgFile = new File(["content"], "email.msg");
+    testForm.file().value.set(msgFile);
+
+    expect(testForm.file().valid()).toBe(true);
+    expect(testForm.file().errors().length).toBe(0);
   });
 
   describe("with 'when' condition", () => {

--- a/src/app/shared/validators/file-type.validator.ts
+++ b/src/app/shared/validators/file-type.validator.ts
@@ -7,7 +7,8 @@ export function fileType(
     when,
   }: {
     /**
-     * An array of the allowed content types the file can have.
+     * An array of the allowed file types the file can have (may be either
+     * content type or file extension with leading dot).
      */
     acceptedFileTypes: ReadonlyArray<string>;
     when?: () => boolean;
@@ -15,7 +16,11 @@ export function fileType(
 ): void {
   validate(path, ({ value }) => {
     const file = value();
-    if (file && !acceptedFileTypes.includes(file.type) && (!when || when())) {
+    if (
+      file &&
+      !isValidFileType(file, acceptedFileTypes) &&
+      (!when || when())
+    ) {
       return {
         kind: "fileType",
         message: `The file type is not allowed.`,
@@ -24,4 +29,15 @@ export function fileType(
 
     return null;
   });
+}
+
+function isValidFileType(
+  file: File,
+  acceptedFileTypes: ReadonlyArray<string>,
+): boolean {
+  return acceptedFileTypes.some((acceptedFileType) =>
+    acceptedFileType.startsWith(".")
+      ? file.name.endsWith(acceptedFileType)
+      : file.type === acceptedFileType,
+  );
 }

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -638,7 +638,7 @@
       "default-placeholder": "Datum wählen..."
     },
     "file-input": {
-      "input-label": "Datei auswählen oder in dieses Fenster ziehen",
+      "input-label": "Datei auswählen oder in dieses Fenster ziehen. Erlaubte Formate: {{acceptedExtensions}}",
       "drop-zone-label": "Datei hierhin ziehen"
     },
     "daysDifference": {

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -638,7 +638,7 @@
       "default-placeholder": "Sélectionner la date..."
     },
     "file-input": {
-      "input-label": "Sélectionner ou faire glisser un fichier dans cette fenêtre",
+      "input-label": "Sélectionner ou faire glisser un fichier dans cette fenêtre. Formats autorisés : {{acceptedExtensions}}",
       "drop-zone-label": "Faire glisser le fichier ici"
     },
     "daysDifference": {

--- a/src/settings.example.js
+++ b/src/settings.example.js
@@ -276,8 +276,8 @@ window.schulverwaltung.settings = {
   // Content types of the files the user is allowed to upload
   dossierAllowedFileTypes: [
     "application/pdf", // .pdf
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
-    "image/png", // .png
+    "message/rfc822", // .eml
+    ".msg", // application/vnd.ms-outlook (proprietary format not known by some OSes)
   ],
 
   // Maximum file size for files of dossier document entries in bytes


### PR DESCRIPTION
#950

Zusammen mit https://github.com/bkd-mba-fbi/evento-portal/pull/299 mergen.

- [x] Link vom Dokument darf erst generiert werden, wenn man darauf klickt (Token läuft sonst ab).
- [ ] ~~Statt png soll jpg als Dateiendung hochgeladen werden können (wir nehmen an, dass jpg weiter verbreitet ist)~~ wird nicht umgesetzt
- [x] Wir schränken bei den Dokumenten ein auf folgende Formate: pdf, msg, eml. Wir entfernen docx und jpg/png aus Datenschutzgründen: Da wir sie nicht im Browser anzeigen können, werden sie direkt heruntergeladen, das ist ein Problem.
- [x] Anpassung bei der Formulierung:
  - de: Datei auswählen oder in dieses Fenster ziehen. Erlaubte Formate: pdf, msg, eml.
  - fr: Sélectionner ou faire glisser un fichier dans cette fenêtre. Formats autorisés : pdf, msg, eml.