### PR TITLE
Dossier edit category filtering

### DIFF
--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.html
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.html
@@ -1,4 +1,4 @@
-@if (entry().isOwner) {
+@if (entry().canEdit) {
   <a [routerLink]="['edit', entry().id]" class="btn btn-icon"
     ><i class="material-icons">edit</i></a
   >

--- a/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-edit-link/student-dossier-edit-link.component.spec.ts
@@ -23,7 +23,7 @@ describe("StudentDossierEditLinkComponent", () => {
       type: "dossier",
       additionalInformation: buildAdditionalInformation(),
       category: "2000267",
-      isOwner: true,
+      canEdit: true,
     };
     fixture.componentRef.setInput("entry", entry);
     fixture.detectChanges();
@@ -34,7 +34,7 @@ describe("StudentDossierEditLinkComponent", () => {
   });
 
   it("does not show edit link if is not owner", () => {
-    fixture.componentRef.setInput("entry", { ...entry, isOwner: false });
+    fixture.componentRef.setInput("entry", { ...entry, canEdit: false });
     fixture.detectChanges();
     expect(element.querySelector("a")).toBeNull();
   });

--- a/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry-body/student-dossier-entry-body.component.spec.ts
@@ -60,7 +60,7 @@ describe("StudentDossierEntryBodyComponent", () => {
         CreationDate: new Date(2000, 0, 23),
       },
       category: "Korrespondenz",
-      isOwner: true,
+      canEdit: true,
     };
     fixture.componentRef.setInput("entry", entry);
     fixture.detectChanges();

--- a/src/app/shared/components/student/student-dossier-entry-description/student-dossier-entry-description.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry-description/student-dossier-entry-description.component.spec.ts
@@ -27,7 +27,7 @@ describe("StudentDossierEntryDescriptionComponent", () => {
         Description: "Lorem ipsum",
       },
       category: "Korrespondenz",
-      isOwner: true,
+      canEdit: true,
     };
     fixture.componentRef.setInput("entry", entry);
     fixture.detectChanges();

--- a/src/app/shared/components/student/student-dossier-entry-footer/student-dossier-entry-footer.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry-footer/student-dossier-entry-footer.component.spec.ts
@@ -49,7 +49,7 @@ describe("StudentDossierEntryFooterComponent", () => {
         CreationDate: new Date(2000, 0, 23),
       },
       category: "Korrespondenz",
-      isOwner: true,
+      canEdit: true,
     };
     fixture.componentRef.setInput("entry", entry);
     fixture.detectChanges();

--- a/src/app/shared/components/student/student-dossier-entry/student-dossier-entry.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier-entry/student-dossier-entry.component.spec.ts
@@ -26,7 +26,7 @@ describe("StudentDossierEntryComponent", () => {
       type: "dossier",
       additionalInformation: buildAdditionalInformation(),
       category: "Korrespondenz",
-      isOwner: true,
+      canEdit: true,
     };
     fixture.componentRef.setInput("entry", entry);
     fixture.detectChanges();

--- a/src/app/shared/components/student/student-dossier/student-dossier.component.spec.ts
+++ b/src/app/shared/components/student/student-dossier/student-dossier.component.spec.ts
@@ -42,7 +42,7 @@ describe("StudentDossierComponent", () => {
               "Bei einem epileptischen Anfall ist folgendes zu tun...",
           },
           category: null,
-          isOwner: false,
+          canEdit: false,
         },
       ]),
       disadvantageEntries$: new BehaviorSubject<
@@ -58,7 +58,7 @@ describe("StudentDossierComponent", () => {
             Description: "20% mehr Zeit bei Prüfungen",
           },
           category: null,
-          isOwner: false,
+          canEdit: false,
         },
       ]),
       filteredDossierEntries$: new BehaviorSubject<
@@ -74,7 +74,7 @@ describe("StudentDossierComponent", () => {
             CreationDate: new Date(2000, 0, 23),
           },
           category: null,
-          isOwner: false,
+          canEdit: false,
         },
         {
           id: 4,
@@ -85,7 +85,7 @@ describe("StudentDossierComponent", () => {
             CreationDate: new Date(2000, 0, 24),
           },
           category: null,
-          isOwner: false,
+          canEdit: false,
         },
       ]),
     };

--- a/src/app/shared/services/student-dossier-edit.service.ts
+++ b/src/app/shared/services/student-dossier-edit.service.ts
@@ -19,6 +19,7 @@ import { AdditionalInformationsRestService } from "src/app/shared/services/addit
 import { LoadingService } from "src/app/shared/services/loading-service";
 import { catch404 } from "src/app/shared/utils/observable";
 import { Subscription } from "../models/subscription.model";
+import { isAllowedDossierCategory } from "../utils/additional-informations";
 import { UnreachableError } from "../utils/error";
 import { notNull } from "../utils/filter";
 import { CoursesRestService } from "./courses-rest.service";
@@ -131,7 +132,7 @@ export class StudentDossierEditService {
   }
 
   private async update(
-    type: "document" | "note",
+    _type: "document" | "note",
     entry: Pick<AdditionalInformation, "Id"> &
       Partial<Omit<AdditionalInformation, "Id">>,
     file: Option<File>,
@@ -157,12 +158,8 @@ export class StudentDossierEditService {
     return this.loadingService.load(
       this.dropDownItemsService.getAdditionalInformationCodes().pipe(
         map((categories) =>
-          categories.filter(
-            (category) =>
-              category.IsActive &&
-              // As a workaround, the type id of the category is in the `Sort`
-              // field. Use this to exclude duplicate categories.
-              category.Sort === String(this.settings.dossierCategoriesTypeId),
+          categories.filter((category) =>
+            isAllowedDossierCategory(category, this.settings),
           ),
         ),
         map((categories) =>

--- a/src/app/shared/services/student-dossier-filter.service.spec.ts
+++ b/src/app/shared/services/student-dossier-filter.service.spec.ts
@@ -16,7 +16,7 @@ describe("StudentDossierFilterService", () => {
     type: "dossier",
     additionalInformation: { ...buildAdditionalInformation(), CodeId: codeId },
     category,
-    isOwner: false,
+    canEdit: false,
   });
 
   beforeEach(() => {

--- a/src/app/shared/services/student-dossier.service.spec.ts
+++ b/src/app/shared/services/student-dossier.service.spec.ts
@@ -1,13 +1,17 @@
 import { TestBed } from "@angular/core/testing";
-import { of } from "rxjs";
+import { BehaviorSubject, Observable, firstValueFrom, of } from "rxjs";
 import { skip } from "rxjs/operators";
 import { buildAdditionalInformation, buildStudent } from "src/spec-builders";
 import { buildTestModuleMetadata, settings } from "src/spec-helpers";
+import { AdditionalInformation } from "../models/additional-informations.model";
 import { TokenPayload } from "../models/token-payload.model";
 import { DropDownItemsRestService } from "./drop-down-items-rest.service";
 import { StorageService } from "./storage.service";
 import { StudentDossierFilterService } from "./student-dossier-filter.service";
-import { StudentDossierService } from "./student-dossier.service";
+import {
+  StudentDossierEntry,
+  StudentDossierService,
+} from "./student-dossier.service";
 import { StudentStateService } from "./student-state.service";
 import { StudentsRestService } from "./students-rest.service";
 
@@ -15,8 +19,10 @@ describe("StudentDossierService", () => {
   let service: StudentDossierService;
   let studentsRestService: jasmine.SpyObj<StudentsRestService>;
   let storageService: jasmine.SpyObj<StorageService>;
+  let studentId$: BehaviorSubject<number>;
 
   beforeEach(() => {
+    studentId$ = new BehaviorSubject(42);
     studentsRestService = jasmine.createSpyObj("StudentsRestService", [
       "getAdditionalInformations",
     ]);
@@ -29,7 +35,7 @@ describe("StudentDossierService", () => {
         providers: [
           {
             provide: StudentStateService,
-            useValue: { studentId$: of(42), student$: of(buildStudent(42)) },
+            useValue: { studentId$, student$: of(buildStudent(42)) },
           },
           { provide: StudentsRestService, useValue: studentsRestService },
           {
@@ -37,9 +43,36 @@ describe("StudentDossierService", () => {
             useValue: {
               getAdditionalInformationCodes: () =>
                 of([
-                  { Key: 2000273, Value: "Korrespondenz" },
-                  { Key: 2000275, Value: "Zeugnis" },
-                  { Key: 2000272, Value: "Gesuch" },
+                  {
+                    Key: 2000273,
+                    Value: "Korrespondenz",
+                    IsActive: true,
+                    Sort: "1011",
+                  },
+                  {
+                    Key: 2000275,
+                    Value: "Zeugnis",
+                    IsActive: true,
+                    Sort: "1011",
+                  },
+                  {
+                    Key: 2000272,
+                    Value: "Gesuch",
+                    IsActive: true,
+                    Sort: "1011",
+                  },
+                  {
+                    Key: 2000276,
+                    Value: "Inaktiv",
+                    IsActive: false,
+                    Sort: "1011",
+                  },
+                  {
+                    Key: 2000277,
+                    Value: "Invalid Type",
+                    IsActive: true,
+                    Sort: "",
+                  },
                 ]),
             },
           },
@@ -51,26 +84,40 @@ describe("StudentDossierService", () => {
     service = TestBed.inject(StudentDossierService);
   });
 
+  async function withEntries(
+    infos: ReadonlyArray<AdditionalInformation>,
+    entries$: Observable<ReadonlyArray<StudentDossierEntry>>,
+    callback: (entries: ReadonlyArray<StudentDossierEntry>) => void,
+  ) {
+    studentsRestService.getAdditionalInformations.and.returnValue(of(infos));
+
+    const promise = firstValueFrom(entries$.pipe(skip(1)));
+    studentId$.next(42);
+    const entries = await promise;
+    callback(entries);
+  }
+
   describe("entries$", () => {
-    it("returns empty list when there are no additional informations", () => {
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries).toEqual([]));
+    it("returns empty list when there are no additional informations", async () => {
+      await withEntries([], service.entries$, (entries) => {
+        expect(entries).toEqual([]);
+      });
     });
 
-    it("filters out entries with a null CodeId", () => {
+    it("filters out entries with a null CodeId", async () => {
       const withCode = { ...buildAdditionalInformation() };
       const withoutCode = { ...buildAdditionalInformation(), CodeId: null };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([withCode, withoutCode]),
-      );
 
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries.length).toBe(1));
+      await withEntries(
+        [withCode, withoutCode],
+        service.entries$,
+        (entries) => {
+          expect(entries.length).toBe(1);
+        },
+      );
     });
 
-    it("sorts entries by CreationDate descending", () => {
+    it("sorts entries by CreationDate descending", async () => {
       const entry = {
         ...buildAdditionalInformation(),
         Id: 1,
@@ -81,176 +128,136 @@ describe("StudentDossierService", () => {
         Id: 2,
         CreationDate: new Date("2024-06-01"),
       };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([entry, newerEntry]),
-      );
 
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) =>
-          expect(entries.map((e) => e.id)).toEqual([2, 1]),
-        );
+      await withEntries([entry, newerEntry], service.entries$, (entries) => {
+        expect(entries.map((e) => e.id)).toEqual([2, 1]);
+      });
     });
   });
 
-  describe("getEntryType", () => {
-    it("get entry type 'information' for dossierImportantInformationCodeId", () => {
+  describe("entry.type", () => {
+    it("get entry type 'information' for dossierImportantInformationCodeId", async () => {
       const info = {
         ...buildAdditionalInformation(),
         CodeId: settings.dossierImportantInformationCodeId,
       };
-      studentsRestService.getAdditionalInformations.and.returnValue(of([info]));
 
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].type).toBe("information"));
-    });
-
-    it("get entry type 'disadvantage' for dossierDisadvantageCompensationCodeId", () => {
-      const info = {
-        ...buildAdditionalInformation(),
-        CodeId: settings.dossierDisadvantageCompensationCodeId,
-      };
-      studentsRestService.getAdditionalInformations.and.returnValue(of([info]));
-
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].type).toBe("disadvantage"));
-    });
-
-    it("get entry type 'dossier' for other CodeId", () => {
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([{ ...buildAdditionalInformation() }]),
-      );
-
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].type).toBe("dossier"));
-    });
-  });
-
-  describe("isOwner", () => {
-    it("returns false when no token payload is available", () => {
-      storageService.getPayload.and.returnValue(null);
-      const info = {
-        ...buildAdditionalInformation(),
-        CreatorName: "testuser",
-      };
-      studentsRestService.getAdditionalInformations.and.returnValue(of([info]));
-
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].isOwner).toBeFalse());
-    });
-
-    it("returns true when the token username matches the entry CreatorName", () => {
-      const payload = {
-        username: "testuser",
-      } as unknown as TokenPayload;
-      storageService.getPayload.and.returnValue(payload);
-      const info = {
-        ...buildAdditionalInformation(),
-        CreatorName: "testuser",
-      };
-      studentsRestService.getAdditionalInformations.and.returnValue(of([info]));
-
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].isOwner).toBeTrue());
-    });
-
-    it("returns false when the token username does not match the entry CreatorName", () => {
-      const payload = {
-        username: "otheruser",
-      } as unknown as TokenPayload;
-      storageService.getPayload.and.returnValue(payload);
-      const info = {
-        ...buildAdditionalInformation(),
-        CreatorName: "testuser",
-      };
-      studentsRestService.getAdditionalInformations.and.returnValue(of([info]));
-
-      service.entries$
-        .pipe(skip(1))
-        .subscribe((entries) => expect(entries[0].isOwner).toBeFalse());
-    });
-  });
-
-  describe("filtered entries", () => {
-    it("informationEntries$ only returns information-type entries", () => {
-      const infoEntry = {
-        ...buildAdditionalInformation(),
-        CodeId: settings.dossierImportantInformationCodeId,
-      };
-      const dossierEntry = { ...buildAdditionalInformation() };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([infoEntry, dossierEntry]),
-      );
-
-      service.informationEntries$.pipe(skip(1)).subscribe((entries) => {
-        expect(entries.length).toBe(1);
+      await withEntries([info], service.entries$, (entries) => {
         expect(entries[0].type).toBe("information");
       });
     });
 
-    it("disadvantageEntries$ only returns disadvantage-type entries", () => {
-      const disadvantageEntry = {
+    it("get entry type 'disadvantage' for dossierDisadvantageCompensationCodeId", async () => {
+      const info = {
         ...buildAdditionalInformation(),
         CodeId: settings.dossierDisadvantageCompensationCodeId,
       };
-      const dossierEntry = { ...buildAdditionalInformation() };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([disadvantageEntry, dossierEntry]),
-      );
 
-      service.disadvantageEntries$.pipe(skip(1)).subscribe((entries) => {
-        expect(entries.length).toBe(1);
+      await withEntries([info], service.entries$, (entries) => {
         expect(entries[0].type).toBe("disadvantage");
       });
     });
 
-    it("dossierEntries$ only returns dossier-type entries", () => {
-      const infoEntry = {
-        ...buildAdditionalInformation(),
-        CodeId: settings.dossierImportantInformationCodeId,
-      };
-      const dossierEntry = { ...buildAdditionalInformation() };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([infoEntry, dossierEntry]),
+    it("get entry type 'dossier' for other CodeId", async () => {
+      await withEntries(
+        [{ ...buildAdditionalInformation() }],
+        service.entries$,
+        (entries) => {
+          expect(entries[0].type).toBe("dossier");
+        },
       );
-
-      service.dossierEntries$.pipe(skip(1)).subscribe((entries) => {
-        expect(entries.length).toBe(1);
-        expect(entries[0].type).toBe("dossier");
-      });
     });
   });
 
-  describe("category", () => {
-    it("sets the matching category for the given CodeId", () => {
+  describe("entry.category", () => {
+    it("sets the matching category for the given CodeId", async () => {
       const entry = {
         ...buildAdditionalInformation(),
       };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([entry]),
-      );
 
-      service.entries$.pipe(skip(1)).subscribe((entries) => {
+      await withEntries([entry], service.entries$, (entries) => {
         expect(entries[0].category).toBe("Korrespondenz");
       });
     });
 
-    it("sets category to null if CodeId does not match", () => {
+    it("sets category to null if CodeId cannot be resolved", async () => {
       const entry = {
         ...buildAdditionalInformation(),
         CodeId: 9999,
       };
-      studentsRestService.getAdditionalInformations.and.returnValue(
-        of([entry]),
-      );
 
-      service.entries$.pipe(skip(1)).subscribe((entries) => {
+      await withEntries([entry], service.entries$, (entries) => {
         expect(entries[0].category).toBeNull();
+      });
+    });
+  });
+
+  describe("entry.canEdit", () => {
+    beforeEach(() => {
+      const payload = {
+        username: "testuser",
+      } as unknown as TokenPayload;
+      storageService.getPayload.and.returnValue(payload);
+    });
+
+    it("is false if category is allowed  but no token payload is available", async () => {
+      storageService.getPayload.and.returnValue(null);
+      const entry = {
+        ...buildAdditionalInformation(),
+        CodeId: 2000273,
+        CreatorName: "testuser",
+      };
+
+      await withEntries([entry], service.entries$, (entries) => {
+        expect(entries[0].canEdit).toBe(false);
+      });
+    });
+
+    it("is false if category is allowed but user is not the author", async () => {
+      const entry = {
+        ...buildAdditionalInformation(),
+        CodeId: 2000273,
+        CreatorName: "otheruser",
+      };
+
+      await withEntries([entry], service.entries$, (entries) => {
+        expect(entries[0].canEdit).toBe(false);
+      });
+    });
+
+    it("is false if category is inactive", async () => {
+      const entry = {
+        ...buildAdditionalInformation(),
+        CodeId: 2000276,
+        CreatorName: "testuser",
+      };
+
+      await withEntries([entry], service.entries$, (entries) => {
+        expect(entries[0].canEdit).toBe(false);
+      });
+    });
+
+    it("is false if category does not have required type", async () => {
+      const entry = {
+        ...buildAdditionalInformation(),
+        CodeId: 2000277,
+        CreatorName: "testuser",
+      };
+
+      await withEntries([entry], service.entries$, (entries) => {
+        expect(entries[0].canEdit).toBe(false);
+      });
+    });
+
+    it("is true if category is allowed", async () => {
+      const entry = {
+        ...buildAdditionalInformation(),
+        CodeId: 2000273,
+        CreatorName: "testuser",
+      };
+
+      await withEntries([entry], service.entries$, (entries) => {
+        expect(entries[0].canEdit).toBe(true);
       });
     });
   });
@@ -267,16 +274,19 @@ describe("StudentDossierService", () => {
         Id: 2,
         CodeId: 2000275,
       };
+
       studentsRestService.getAdditionalInformations.and.returnValue(
         of([korrespondenz, zeugnis]),
       );
 
-      service.filteredDossierEntries$.pipe(skip(1)).subscribe((entries) => {
-        expect(entries.map((e) => e.id)).toEqual([
-          korrespondenz.Id,
-          zeugnis.Id,
-        ]);
-      });
+      const callback = jasmine.createSpy("callback");
+      service.filteredDossierEntries$.subscribe(callback);
+      studentId$.next(42);
+
+      const entries: ReadonlyArray<StudentDossierEntry> =
+        callback.calls.mostRecent().args[0];
+
+      expect(entries.map((e) => e.id)).toEqual([korrespondenz.Id, zeugnis.Id]);
     });
 
     it("returns only selected dossier entries when a category is selected", () => {
@@ -290,17 +300,73 @@ describe("StudentDossierService", () => {
         Id: 2,
         CodeId: 2000275,
       };
+
       studentsRestService.getAdditionalInformations.and.returnValue(
         of([korrespondenz, zeugnis]),
       );
 
-      TestBed.inject(StudentDossierFilterService).setSelectedCategories([
-        "Zeugnis",
-      ]);
+      const callback = jasmine.createSpy("callback");
+      service.filteredDossierEntries$.subscribe(callback);
+      studentId$.next(42);
+      const filterService = TestBed.inject(StudentDossierFilterService);
+      filterService.setSelectedCategories(["Zeugnis"]);
 
-      service.filteredDossierEntries$.pipe(skip(1)).subscribe((entries) => {
-        expect(entries.map((e) => e.id)).toEqual([zeugnis.Id]);
-      });
+      const entries: ReadonlyArray<StudentDossierEntry> =
+        callback.calls.mostRecent().args[0];
+      expect(entries.map((e) => e.id)).toEqual([zeugnis.Id]);
+    });
+  });
+
+  describe("entries by type", () => {
+    it("informationEntries$ only returns information-type entries", async () => {
+      const infoEntry = {
+        ...buildAdditionalInformation(),
+        CodeId: settings.dossierImportantInformationCodeId,
+      };
+      const dossierEntry = { ...buildAdditionalInformation() };
+
+      await withEntries(
+        [infoEntry, dossierEntry],
+        service.informationEntries$,
+        (entries) => {
+          expect(entries.length).toBe(1);
+          expect(entries[0].type).toBe("information");
+        },
+      );
+    });
+
+    it("disadvantageEntries$ only returns disadvantage-type entries", async () => {
+      const disadvantageEntry = {
+        ...buildAdditionalInformation(),
+        CodeId: settings.dossierDisadvantageCompensationCodeId,
+      };
+      const dossierEntry = { ...buildAdditionalInformation() };
+
+      await withEntries(
+        [disadvantageEntry, dossierEntry],
+        service.disadvantageEntries$,
+        (entries) => {
+          expect(entries.length).toBe(1);
+          expect(entries[0].type).toBe("disadvantage");
+        },
+      );
+    });
+
+    it("dossierEntries$ only returns dossier-type entries", async () => {
+      const infoEntry = {
+        ...buildAdditionalInformation(),
+        CodeId: settings.dossierImportantInformationCodeId,
+      };
+      const dossierEntry = { ...buildAdditionalInformation() };
+
+      await withEntries(
+        [infoEntry, dossierEntry],
+        service.dossierEntries$,
+        (entries) => {
+          expect(entries.length).toBe(1);
+          expect(entries[0].type).toBe("dossier");
+        },
+      );
     });
   });
 });

--- a/src/app/shared/services/student-dossier.service.ts
+++ b/src/app/shared/services/student-dossier.service.ts
@@ -10,8 +10,11 @@ import {
 } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { SETTINGS, Settings } from "../../settings";
-import { AdditionalInformation } from "../models/additional-informations.model";
-import { DropDownItem } from "../models/drop-down-item.model";
+import {
+  AdditionalInformation,
+  AdditionalInformationCode,
+} from "../models/additional-informations.model";
+import { isAllowedDossierCategory } from "../utils/additional-informations";
 import { DropDownItemsRestService } from "./drop-down-items-rest.service";
 import { LoadingService } from "./loading-service";
 import { StorageService } from "./storage.service";
@@ -29,7 +32,7 @@ export interface StudentDossierEntry {
   type: StudentDossierEntryType;
   additionalInformation: AdditionalInformation;
   category: Option<string>;
-  isOwner: boolean;
+  canEdit: boolean;
 }
 
 const STUDENT_DOSSIER_CONTEXT = "student-dossier";
@@ -121,7 +124,9 @@ export class StudentDossierService implements OnDestroy {
     );
   }
 
-  private loadCategories(): Observable<ReadonlyArray<DropDownItem>> {
+  private loadCategories(): Observable<
+    ReadonlyArray<AdditionalInformationCode>
+  > {
     return this.loadingService.load(
       this.dropDownItemsService.getAdditionalInformationCodes(),
       {
@@ -132,19 +137,22 @@ export class StudentDossierService implements OnDestroy {
 
   private buildEntry(
     info: AdditionalInformation,
-    categories: ReadonlyArray<DropDownItem>,
+    categories: ReadonlyArray<AdditionalInformationCode>,
   ): StudentDossierEntry {
     const codeId = info.CodeId;
+    const category = codeId
+      ? (categories.find((c) => String(c.Key) === String(codeId)) ?? null)
+      : null;
+    const allowedCategory = Boolean(
+      category && isAllowedDossierCategory(category, this.settings),
+    );
 
     return {
       id: info.Id,
       type: this.getEntryType(info),
       additionalInformation: info,
-      category: codeId
-        ? (categories.find((c) => String(c.Key) === String(codeId))?.Value ??
-          null)
-        : null,
-      isOwner: this.isOwner(info),
+      category: category?.Value ?? null,
+      canEdit: this.isOwner(info) && allowedCategory, // The author of the entry can only edit it, if it has a category that is selectable in the frontend
     };
   }
 

--- a/src/app/shared/utils/additional-informations.ts
+++ b/src/app/shared/utils/additional-informations.ts
@@ -1,0 +1,14 @@
+import { Settings } from "src/app/settings";
+import { AdditionalInformationCode } from "../models/additional-informations.model";
+
+export function isAllowedDossierCategory(
+  category: AdditionalInformationCode,
+  settings: Settings,
+): boolean {
+  return (
+    category.IsActive &&
+    // As a workaround, the type id of the category is in the `Sort`
+    // field. Use this to exclude duplicate categories.
+    category.Sort === String(settings.dossierCategoriesTypeId)
+  );
+}


### PR DESCRIPTION
#925 

- Bezüglich Filtering der Kategorien ist keine Änderung nötig, die Kategorien welche nicht ausgewählt werden können, haben einen leeren Sort Wert und werden bereits gefiltert.
- Wenn jemand im Backend einen Eintrag mit einer Kategorie erstellt, welche im Frontend nicht ausgewählt werden kann:
  - [x] Variante 1: Der Eintrag ist nicht bearbeitbar im Frontend (kein Stift)
  - [ ] ~~Variante 2: Der Eintrag kann bearbeitet werden, aber die Kategorie ist nicht änderbar (Problem: Die Kategorie wird nicht im Select zur Verfügung stehen, Select komplett weglassen?)~~

Testen:

Eintrag «test alle» unter «Information» bei «Berger Laura» mit l1. War vor dem Change bearbeitbar und ist es nun nicht mehr.
