### PR TITLE
My absences teachers

### DIFF
--- a/src/app/dashboard/components/dashboard-timetable/dashboard-timetable.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-timetable/dashboard-timetable.component.spec.ts
@@ -130,7 +130,9 @@ describe("DashboardTimetableComponent", () => {
       entry1.EventId = 10;
       entry1.EventNumber = "3-1-E-S3-Test-9a";
       entry1.EventDesignation = "Mathematik";
-      entry1.EventManagerInformation = "Leonhard Euler";
+      entry1.LessonTeachers = [
+        { Id: 1, PersonId: 1, Lastname: "Euler", Firstname: "Leonhard" },
+      ];
       entry1.EventLocation = "109";
       entry1.Rooms = [{ Id: 109, Designation: "109" }];
 
@@ -142,7 +144,9 @@ describe("DashboardTimetableComponent", () => {
       entry2.EventId = 20;
       entry2.EventNumber = "3-2-E-S3-Test-8c";
       entry2.EventDesignation = "Zeichnen";
-      entry2.EventManagerInformation = "Pablo Picasso";
+      entry2.LessonTeachers = [
+        { Id: 2, PersonId: 2, Lastname: "Picasso", Firstname: "Pablo" },
+      ];
       entry2.EventLocation = "502";
       entry2.Rooms = [{ Id: 502, Designation: "502" }];
 
@@ -293,7 +297,9 @@ describe("DashboardTimetableComponent", () => {
       );
       entry1.EventId = 10;
       entry1.EventDesignation = "Mathematik";
-      entry1.EventManagerInformation = "Leonhard Euler";
+      entry1.LessonTeachers = [
+        { Id: 1, PersonId: 1, Lastname: "Euler", Firstname: "Leonhard" },
+      ];
       entry1.EventLocation = "109";
       entry1.Rooms = [{ Id: 109, Designation: "109" }];
 
@@ -304,7 +310,9 @@ describe("DashboardTimetableComponent", () => {
       );
       entry2.EventId = 20;
       entry2.EventDesignation = "Zeichnen";
-      entry2.EventManagerInformation = "Pablo Picasso";
+      entry2.LessonTeachers = [
+        { Id: 2, PersonId: 2, Lastname: "Picasso", Firstname: "Pablo" },
+      ];
       entry2.EventLocation = "502";
       entry2.Rooms = [{ Id: 502, Designation: "502" }];
 
@@ -338,7 +346,7 @@ describe("DashboardTimetableComponent", () => {
       expect(label?.textContent?.trim()).toBe("Mathematik");
 
       expect(rows[0].querySelector("td.teacher")?.textContent?.trim()).toBe(
-        "Leonhard Euler",
+        "Euler Leonhard",
       );
 
       expect(rows[0].querySelector("td.room")?.textContent).toContain("109");
@@ -352,7 +360,7 @@ describe("DashboardTimetableComponent", () => {
       expect(label?.textContent?.trim()).toBe("Zeichnen");
 
       expect(rows[1].querySelector("td.teacher")?.textContent?.trim()).toBe(
-        "Pablo Picasso",
+        "Picasso Pablo",
       );
 
       expect(rows[1].querySelector("td.room")?.textContent).toContain("502");

--- a/src/app/dashboard/utils/dashboard-timetable-entry.spec.ts
+++ b/src/app/dashboard/utils/dashboard-timetable-entry.spec.ts
@@ -19,7 +19,9 @@ describe("Dashboard timetable entry utilities", () => {
         EventNumber: "1-1-E-S3-GYMweb24-27a",
         EventDesignation: "Englisch-S3",
         EventLocation: "1.01",
-        EventManagerInformation: "Doe Jane",
+        LessonTeachers: [
+          { Id: 1, PersonId: 1, Lastname: "Doe", Firstname: "Jane" },
+        ],
         Rooms: [{ Id: 1016, Designation: "1.01" }],
       };
       const result = convertTimetableEntry(entry);

--- a/src/app/dashboard/utils/dashboard-timetable-entry.ts
+++ b/src/app/dashboard/utils/dashboard-timetable-entry.ts
@@ -1,6 +1,7 @@
 import uniq from "lodash-es/uniq";
 import { LessonStudyClass } from "src/app/shared/models/lesson-study-class.model";
 import { TimetableEntry } from "src/app/shared/models/timetable-entry.model";
+import { createTeacherString } from "src/app/shared/utils/timetable-entries";
 
 export type DashboardTimetableEntry = {
   id: string;
@@ -68,7 +69,7 @@ export function convertTimetableEntry(
     // studyClass: (entry.EventNumber.match(/[-_]([^-_]+)$/) ?? [])[1], // The last part of the EventNumber is the study class (e.g. "3-1-E-S3-GYMweb25-26b", the class is "26b")
 
     room: entry.Rooms?.map((room) => room.Designation).join(", ") || undefined,
-    teacher: entry.EventManagerInformation || undefined,
+    teacher: createTeacherString(entry.LessonTeachers) ?? undefined,
   };
 }
 

--- a/src/app/my-absences/components/my-absences-report-header/my-absences-report-header.component.scss
+++ b/src/app/my-absences/components/my-absences-report-header/my-absences-report-header.component.scss
@@ -10,9 +10,11 @@
 .filters {
   display: flex;
   flex-wrap: wrap;
+  align-items: end;
 }
 
-.form-group {
+.form-group,
+.buttons {
   flex: 1;
   min-width: 20rem;
   max-width: 40rem;
@@ -22,7 +24,6 @@
 
 .buttons {
   flex: none;
-  margin-top: $font-size-base * $line-height-base;
   margin-right: 0;
 }
 

--- a/src/app/my-absences/services/my-absences-report-state.service.ts
+++ b/src/app/my-absences/services/my-absences-report-state.service.ts
@@ -16,6 +16,7 @@ import {
 import { StorageService } from "src/app/shared/services/storage.service";
 import { StudentsRestService } from "src/app/shared/services/students-rest.service";
 import { Paginated } from "src/app/shared/utils/pagination";
+import { createTeacherString } from "src/app/shared/utils/timetable-entries";
 
 export interface ReportAbsencesFilter {
   dateFrom: Option<Date>;
@@ -203,7 +204,8 @@ export class MyAbsencesReportStateService extends PaginatedEntriesService<
       Type: (absence || dispensation)?.Type || null,
       StudentFullName: (absence || dispensation)?.StudentFullName || "",
       StudyClassNumber: "", // Currently not available on timetable entry
-      TeacherInformation: timetableEntry.EventManagerInformation ?? null,
+      TeacherInformation:
+        createTeacherString(timetableEntry.LessonTeachers) ?? null,
     };
   }
 

--- a/src/app/my-absences/services/my-absences.service.ts
+++ b/src/app/my-absences/services/my-absences.service.ts
@@ -20,6 +20,7 @@ import { StudentsRestService } from "src/app/shared/services/students-rest.servi
 import { notNull } from "src/app/shared/utils/filter";
 import { spread } from "src/app/shared/utils/function";
 import { sortLessonPresencesByDate } from "src/app/shared/utils/lesson-presences";
+import { createTeacherString } from "src/app/shared/utils/timetable-entries";
 
 @Injectable()
 export class MyAbsencesService {
@@ -240,7 +241,7 @@ export class MyAbsencesService {
       Type: absence.Type,
       StudentFullName: absence.StudentFullName,
       StudyClassNumber: "", // Currently not available on timetable entry
-      TeacherInformation: entry.EventManagerInformation ?? null,
+      TeacherInformation: createTeacherString(entry.LessonTeachers),
     };
   }
 }

--- a/src/app/shared/models/timetable-entry.model.ts
+++ b/src/app/shared/models/timetable-entry.model.ts
@@ -1,6 +1,18 @@
 import * as t from "io-ts";
 import { LocalDateTimeFromString, Maybe, Option } from "./common-types";
 
+const Room = t.type({
+  Id: t.number,
+  Designation: t.string,
+});
+
+const LessonTeacher = t.type({
+  PersonId: t.number,
+  Lastname: t.string,
+  Firstname: t.string,
+  Id: t.number,
+});
+
 const TimetableEntry = t.type({
   Id: t.number,
   From: LocalDateTimeFromString,
@@ -11,7 +23,7 @@ const TimetableEntry = t.type({
   EventDesignation: t.string,
   // EventColor: t.number,
   EventLocation: Option(t.string),
-  EventManagerInformation: Maybe(t.string),
+  // EventManagerInformation: Maybe(t.string),
   // EventManagerId: t.number,
   // EventManagerLastname: Option(t.string),
   // EventManagerFirstname: Option(t.string),
@@ -19,12 +31,14 @@ const TimetableEntry = t.type({
   // LessonTeacherId: t.number,
   // LessonTeacherLastname: t.string,
   // LessonTeacherFirstname: t.string,
+  LessonTeachers: Maybe(t.readonlyArray(LessonTeacher)),
   // RoomId: t.number,
   // Room: t.string,
-  Rooms: Maybe(
-    t.readonlyArray(t.type({ Id: t.number, Designation: t.string })),
-  ),
+  Rooms: Maybe(t.readonlyArray(Room)),
   // HRef: Option(t.string),
 });
+
 type TimetableEntry = t.TypeOf<typeof TimetableEntry>;
-export { TimetableEntry };
+type LessonTeacher = t.TypeOf<typeof LessonTeacher>;
+type Room = t.TypeOf<typeof Room>;
+export { TimetableEntry, LessonTeacher, Room };

--- a/src/app/shared/services/students-rest.service.spec.ts
+++ b/src/app/shared/services/students-rest.service.spec.ts
@@ -79,7 +79,7 @@ describe("StudentsRestService", () => {
 
       httpTestingController
         .expectOne(
-          "https://eventotest.api/Students/39361/TimetableEntries/CurrentSemester?fields=Id,From,To,EventId,EventNumber,EventDesignation,EventLocation,Rooms,EventManagerInformation&expand=Rooms",
+          "https://eventotest.api/Students/39361/TimetableEntries/CurrentSemester?expand=LessonTeachers,Rooms&fields=Id,From,To,EventId,EventNumber,EventDesignation,EventLocation,Rooms,LessonTeachers",
         )
         .flush(t.array(TimetableEntry).encode([entry1, entry2]));
     });

--- a/src/app/shared/services/students-rest.service.ts
+++ b/src/app/shared/services/students-rest.service.ts
@@ -100,12 +100,25 @@ export class StudentsRestService extends TypeaheadRestService<typeof Student> {
     studentId: number,
     params: HttpParams | Dict<string> = {},
   ): Observable<ReadonlyArray<TimetableEntry>> {
+    let additionalParams =
+      params instanceof HttpParams
+        ? params
+        : new HttpParams({ fromObject: params });
+
+    additionalParams = additionalParams.set(
+      "expand",
+      [
+        ...(additionalParams.get("expand")?.split(",") ?? []),
+        "LessonTeachers",
+      ].join(","),
+    );
+
     return fetchTimetableEntries(
       this.http,
       `${this.baseUrl}/${studentId}/TimetableEntries/CurrentSemester`,
       {
-        params,
-        additionalFields: ["EventManagerInformation"],
+        params: additionalParams,
+        additionalFields: ["LessonTeachers"],
       },
     );
   }

--- a/src/app/shared/utils/timetable-entries.ts
+++ b/src/app/shared/utils/timetable-entries.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders, HttpParams } from "@angular/common/http";
 import { Observable, switchMap } from "rxjs";
-import { TimetableEntry } from "../models/timetable-entry.model";
+import { LessonTeacher, TimetableEntry } from "../models/timetable-entry.model";
 import { decodeArray } from "./decode";
 
 export function fetchTimetableEntries(
@@ -34,11 +34,24 @@ export function fetchTimetableEntries(
         ...(additionalFields ?? []),
       ].join(","),
     )
-    .set("expand", "Rooms");
+    .set(
+      "expand",
+      [...(params.get("expand")?.split(",") ?? []), "Rooms"].join(","),
+    );
+
   return http
     .get<unknown>(url, {
       ...options,
       params,
     })
     .pipe(switchMap(decodeArray(TimetableEntry)));
+}
+
+export function createTeacherString(
+  lessonTeachers?: Option<ReadonlyArray<LessonTeacher>>,
+): Option<string> {
+  return (
+    lessonTeachers?.map((t) => `${t.Lastname} ${t.Firstname}`)?.join(", ") ||
+    null
+  );
 }

--- a/src/spec-builders.ts
+++ b/src/spec-builders.ts
@@ -45,6 +45,7 @@ import { Result, Test } from "./app/shared/models/test.model";
 import { TimetableEntry } from "./app/shared/models/timetable-entry.model";
 import { TokenPayload } from "./app/shared/models/token-payload.model";
 import { UserSettings } from "./app/shared/models/user-settings.model";
+import { createTeacherString } from "./app/shared/utils/timetable-entries";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -131,7 +132,8 @@ export function buildLessonPresenceFromTimetableEntry(
     Type: null,
     StudentFullName: "",
     StudyClassNumber: "",
-    TeacherInformation: timetableEntry.EventManagerInformation ?? null,
+    TeacherInformation:
+      createTeacherString(timetableEntry.LessonTeachers) ?? null,
   };
 }
 
@@ -715,7 +717,7 @@ export function buildTimetableEntry(
     EventId: 0,
     EventNumber: "",
     EventDesignation: "",
-    EventManagerInformation: "",
+    LessonTeachers: [],
     EventLocation: "",
     Rooms: undefined,
   };


### PR DESCRIPTION
#938

Überall dort, wo wir bei den TimetableEntries die `EventManagerInformation` geladen hatten, verwenden wir nun die `LessonTeachers`. Unter «Meine Absenzen» habe ich keinen Unterschied festgestellt (der beschriebene Testfall ist nicht mehr präsent), aber auf dem Dashboard beim Stundenplan (als s1), wird nun bei den Deutschlektionen nur noch eine Lehrperson angezeigt statt zwei.