### PR TITLE
Hide instructor email edit link if email is invalid

### DIFF
--- a/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.html
+++ b/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.html
@@ -89,7 +89,7 @@
 
     @let editLink = instructorEmailEditLink();
     @let editLabel = instructorEmailEditLabel();
-    @if (editLink) {
+    @if (email && editLink) {
       <a
         class="btn btn-primary btn-icon me-2"
         [routerLink]="editLink"

--- a/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.spec.ts
+++ b/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.spec.ts
@@ -42,34 +42,94 @@ describe("StudentContactApprenticeshipComponent", () => {
   });
 
   describe("instructor email", () => {
-    it("renders email if present", () => {
-      student.Custom1 = "test@example.com";
-      fixture.componentRef.setInput("student", { ...student });
-      fixture.detectChanges();
+    describe("email value", () => {
+      it("renders email if present", () => {
+        student.Custom1 = "test@example.com";
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.detectChanges();
 
-      const link = getInstructorEmailSection().querySelector("a");
-      expect(link).not.toBeNull();
-      expect(link?.getAttribute("href")).toBe("mailto:test@example.com");
+        const link = getInstructorEmailSection().querySelector("a");
+        expect(link).not.toBeNull();
+        expect(link?.getAttribute("href")).toBe("mailto:test@example.com");
+      });
+
+      it("renders dash for non-email value", () => {
+        student.Custom1 = "Lorem ipsum dolor sit amet";
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.detectChanges();
+
+        const section = getInstructorEmailSection();
+        expect(section.textContent).toContain("–");
+        expect(section.querySelector("a")).toBeNull();
+      });
+
+      it("renders dash for null value", () => {
+        student.Custom1 = null;
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.detectChanges();
+
+        const section = getInstructorEmailSection();
+        expect(section.textContent).toContain("–");
+        expect(section.querySelector("a")).toBeNull();
+      });
     });
 
-    it("renders dash for non-email value", () => {
-      student.Custom1 = "Lorem ipsum dolor sit amet";
-      fixture.componentRef.setInput("student", { ...student });
-      fixture.detectChanges();
+    describe("edit link", () => {
+      it("renders edit link if present and email is valid", () => {
+        student.Custom1 = "test@example.com";
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.componentRef.setInput(
+          "instructorEmailEditLink",
+          "/edit-instructor-email",
+        );
+        fixture.componentRef.setInput(
+          "instructorEmailEditLabel",
+          "Edit instructor email",
+        );
+        fixture.detectChanges();
 
-      const section = getInstructorEmailSection();
-      expect(section.textContent).toContain("–");
-      expect(section.querySelector("a")).toBeNull();
-    });
+        const section = getInstructorEmailSection();
 
-    it("renders dash for null value", () => {
-      student.Custom1 = null;
-      fixture.componentRef.setInput("student", { ...student });
-      fixture.detectChanges();
+        const editLink = section.querySelector(
+          "[aria-label='Edit instructor email']",
+        );
+        expect(editLink).not.toBeNull();
+        expect(editLink?.getAttribute("href")).toBe("/edit-instructor-email");
+      });
 
-      const section = getInstructorEmailSection();
-      expect(section.textContent).toContain("–");
-      expect(section.querySelector("a")).toBeNull();
+      it("does not render edit link if present and email is invalid", () => {
+        student.Custom1 = "Lorem ipsum dolor sit amet";
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.componentRef.setInput(
+          "instructorEmailEditLink",
+          "/edit-instructor-email",
+        );
+        fixture.componentRef.setInput(
+          "instructorEmailEditLabel",
+          "Edit instructor email",
+        );
+        fixture.detectChanges();
+
+        const section = getInstructorEmailSection();
+
+        const editLink = section.querySelector(
+          "[aria-label='Edit instructor email']",
+        );
+        expect(editLink).toBeNull();
+      });
+
+      it("does not render edit link if absent and email is valid", () => {
+        student.Custom1 = "test@example.com";
+        fixture.componentRef.setInput("student", { ...student });
+        fixture.detectChanges();
+
+        const section = getInstructorEmailSection();
+
+        const editLink = section.querySelector(
+          "[aria-label='Edit instructor email']",
+        );
+        expect(editLink).toBeNull();
+      });
     });
 
     function getInstructorEmailSection(): HTMLDivElement {


### PR DESCRIPTION
#1020 

~~Kann man leider aktuell nicht testen, weil das `"practicalTrainerActionEMail": false` Setting gesetzt ist. ~~ → Kann man jetzt testen.