### PR TITLE
Filter current/past events client-side & consider null dates

### DIFF
--- a/src/app/events/services/events-state.service.spec.ts
+++ b/src/app/events/services/events-state.service.spec.ts
@@ -196,21 +196,30 @@ describe("EventsStateService", () => {
   });
 
   describe("with ClassTeacherRole", () => {
+    let firstEntry: EventEntry;
+    let restEntries: ReadonlyArray<EventEntry>;
+
     beforeEach(() => {
       service.setRoles("ClassTeacherRole;TeacherRole");
+
+      firstEntry = courseEntries[0];
+      restEntries = courseEntries.slice(1);
+
+      courses[1].DateTo = new Date("2022-01-01T00:00:00");
+      firstEntry.dateTo = new Date("2022-01-01T00:00:00");
     });
 
     describe("with scope 'current'", () => {
-      it("loads events", () => {
+      it("loads events but only emits current events", () => {
         service.getEntries().subscribe((result) => {
           expect(result).toEqual([
             ...studyClassEntries,
             ...assessmentEntries,
-            ...courseEntries,
+            ...restEntries,
           ]);
         });
 
-        expectCoursesScopeAllRequest();
+        expectCoursesRequest();
         expectFormativeAssessmentsRequest();
         expectStudyClassesRequest();
 
@@ -223,12 +232,14 @@ describe("EventsStateService", () => {
         service.setScope("past");
       });
 
-      it("loads events", () => {
+      it("loads events but only emits past events", () => {
         service.getEntries().subscribe((result) => {
-          expect(result).toEqual([...courseEntries]);
+          expect(result).toEqual([firstEntry]);
         });
 
-        expectCoursesScopePastRequest();
+        expectCoursesRequest();
+        expectFormativeAssessmentsRequest();
+        expectStudyClassesRequest();
 
         httpTestingController.verify();
       });
@@ -240,75 +251,34 @@ describe("EventsStateService", () => {
       service.setRoles("TeacherRole");
     });
 
-    describe("with scope 'current'", () => {
-      it("loads events", () => {
-        service
-          .getEntries()
-          .subscribe((result) =>
-            expect(result.map((r) => r.id)).toEqual([2, 4, 1, 3]),
-          );
+    it("loads events", () => {
+      service
+        .getEntries()
+        .subscribe((result) =>
+          expect(result.map((r) => r.id)).toEqual([2, 4, 1, 3]),
+        );
 
-        expectCoursesScopeAllRequest();
+      expectCoursesRequest();
 
-        httpTestingController.verify();
-      });
-
-      it("loads events with ratings", () => {
-        service
-          .getEntries(true)
-          .subscribe((result) =>
-            expect(result.map((r) => r.id)).toEqual([2, 4, 3]),
-          );
-
-        expectCoursesScopeAllRequest();
-
-        httpTestingController.verify();
-      });
+      httpTestingController.verify();
     });
 
-    describe("with scope 'past'", () => {
-      beforeEach(() => {
-        service.setScope("past");
-      });
+    it("loads events with ratings", () => {
+      service
+        .getEntries(true)
+        .subscribe((result) =>
+          expect(result.map((r) => r.id)).toEqual([2, 4, 3]),
+        );
 
-      it("loads events", () => {
-        service
-          .getEntries()
-          .subscribe((result) =>
-            expect(result.map((r) => r.id)).toEqual([2, 4, 1, 3]),
-          );
+      expectCoursesRequest();
 
-        expectCoursesScopePastRequest();
-
-        httpTestingController.verify();
-      });
-
-      it("loads events with ratings", () => {
-        service
-          .getEntries(true)
-          .subscribe((result) =>
-            expect(result.map((r) => r.id)).toEqual([2, 4, 3]),
-          );
-
-        expectCoursesScopePastRequest();
-
-        httpTestingController.verify();
-      });
+      httpTestingController.verify();
     });
   });
 
-  function expectCoursesScopeAllRequest(response = courses): void {
+  function expectCoursesRequest(response = courses): void {
     const url =
-      "https://eventotest.api/Courses/?filter.DateTo=%3E2022-03-02&expand=EvaluationStatusRef,AttendanceRef,Classes,FinalGrades&filter.StatusId=;14030;14025;14017;14020;10350;10335;10355;10315;10330;1032510320;10340;10345;10230;10225;10240;10260;10217;10235;10220;10226;10227;10250;10300";
-
-    httpTestingController
-      .expectOne(url)
-      .flush(t.array(Course).encode(response));
-  }
-
-  function expectCoursesScopePastRequest(response = courses): void {
-    const url =
-      "https://eventotest.api/Courses/?filter.DateTo=%3C2022-03-03&expand=EvaluationStatusRef,AttendanceRef,Classes,FinalGrades&filter.StatusId=;14030;14025;14017;14020;10350;10335;10355;10315;10330;1032510320;10340;10345;10230;10225;10240;10260;10217;10235;10220;10226;10227;10250;10300";
+      "https://eventotest.api/Courses/?expand=EvaluationStatusRef,AttendanceRef,Classes,FinalGrades&filter.StatusId=;14030;14025;14017;14020;10350;10335;10355;10315;10330;1032510320;10340;10345;10230;10225;10240;10260;10217;10235;10220;10226;10227;10250;10300";
 
     httpTestingController
       .expectOne(url)

--- a/src/app/events/services/events-state.service.ts
+++ b/src/app/events/services/events-state.service.ts
@@ -16,7 +16,7 @@ import { StudyClass } from "src/app/shared/models/study-class.model";
 import { CoursesRestService } from "src/app/shared/services/courses-rest.service";
 import { LoadingService } from "src/app/shared/services/loading-service";
 import { StudyClassesRestService } from "src/app/shared/services/study-classes-rest.service";
-import { getCourseFilterParamsForScope } from "src/app/shared/utils/courses";
+import { filterEventsForScope } from "src/app/shared/utils/courses";
 import { spread } from "src/app/shared/utils/function";
 import { hasRole } from "src/app/shared/utils/roles";
 import { searchEntries } from "src/app/shared/utils/search";
@@ -105,19 +105,18 @@ export class EventsStateService {
   }
 
   private getEvents(): Observable<ReadonlyArray<EventEntry>> {
-    const unratedCourses$ = combineLatest([this.scope$, this.roles$]).pipe(
-      switchMap(spread(this.loadUnratedCourses.bind(this))),
+    const unratedCourses$ = this.roles$.pipe(
+      switchMap(this.loadUnratedCourses.bind(this)),
     );
-    const formativeAssessments$ = combineLatest([
-      this.scope$,
-      this.isClassTeacher$,
-    ]).pipe(switchMap(spread(this.loadFormativeAssessments.bind(this))));
-    const studyClasses$ = combineLatest([
-      this.scope$,
-      this.isClassTeacher$,
-    ]).pipe(switchMap(spread(this.loadStudyClasses.bind(this))));
+    const formativeAssessments$ = this.isClassTeacher$.pipe(
+      switchMap(this.loadFormativeAssessments.bind(this)),
+    );
+    const studyClasses$ = this.isClassTeacher$.pipe(
+      switchMap(this.loadStudyClasses.bind(this)),
+    );
 
     return combineLatest([
+      this.scope$,
       unratedCourses$,
       formativeAssessments$,
       studyClasses$,
@@ -125,20 +124,17 @@ export class EventsStateService {
   }
 
   private loadUnratedCourses(
-    scope: EventScope,
     roles: Option<string>,
   ): Observable<ReadonlyArray<Course>> {
-    const params = getCourseFilterParamsForScope(scope);
     return this.loadingService
-      .load(this.coursesRestService.getCourses(roles, params))
+      .load(this.coursesRestService.getCourses(roles))
       .pipe(map((courses) => courses.filter((c) => !isRated(c))));
   }
 
   private loadFormativeAssessments(
-    scope: EventScope,
     isClassTeacher: boolean,
   ): Observable<ReadonlyArray<StudyClass>> {
-    if (scope === "past" || !isClassTeacher) return of([]);
+    if (!isClassTeacher) return of([]);
 
     return this.loadingService.load(
       this.studyClassRestService.getActiveFormativeAssessments(),
@@ -146,15 +142,15 @@ export class EventsStateService {
   }
 
   private loadStudyClasses(
-    scope: EventScope,
     isClassTeacher: boolean,
   ): Observable<ReadonlyArray<StudyClass>> {
-    if (scope === "past" || !isClassTeacher) return of([]);
+    if (!isClassTeacher) return of([]);
 
     return this.loadingService.load(this.studyClassRestService.getActive());
   }
 
   private createAndSortEvents(
+    scope: EventScope,
     courses: ReadonlyArray<Course>,
     formativeAssessments: ReadonlyArray<StudyClass>,
     studyClasses: ReadonlyArray<StudyClass>,
@@ -163,16 +159,17 @@ export class EventsStateService {
       (c) => !formativeAssessments.map((fa) => fa.Id).includes(c.Id),
     );
     return [
-      ...this.createFromCourses(courses),
-      ...this.createFromAssessments(formativeAssessments),
-      ...this.createFromStudyClasses(classesWithoutAssessments),
+      ...this.createFromCourses(scope, courses),
+      ...this.createFromAssessments(scope, formativeAssessments),
+      ...this.createFromStudyClasses(scope, classesWithoutAssessments),
     ].sort((a, b) => a.designation.localeCompare(b.designation));
   }
 
   private createFromCourses(
+    scope: EventScope,
     courses: ReadonlyArray<Course>,
   ): ReadonlyArray<EventEntry> {
-    return courses.map((course) => {
+    return filterEventsForScope(scope, courses).map((course) => {
       const state = getEventState(course);
 
       return {
@@ -196,10 +193,12 @@ export class EventsStateService {
   }
 
   private createFromAssessments(
+    scope: EventScope,
     studyClasses: ReadonlyArray<StudyClass>,
   ): ReadonlyArray<EventEntry> {
-    const events = this.createFromStudyClasses(studyClasses);
+    if (scope !== "current") return [];
 
+    const events = this.createFromStudyClasses(scope, studyClasses);
     return events.map((e) => ({
       ...e,
       state: EventState.Rating,
@@ -209,8 +208,11 @@ export class EventsStateService {
   }
 
   private createFromStudyClasses(
+    scope: EventScope,
     studyClasses: ReadonlyArray<StudyClass>,
   ): ReadonlyArray<EventEntry> {
+    if (scope !== "current") return [];
+
     return studyClasses.map((studyClass) => ({
       id: studyClass.Id,
       designation: studyClass.Number,

--- a/src/app/my-grades/components/my-grades-show/my-grades-show.component.html
+++ b/src/app/my-grades/components/my-grades-show/my-grades-show.component.html
@@ -1,4 +1,4 @@
-@let courses = myGradesService.studentCoursesSorted$ | async;
+@let courses = myGradesService.studentCourses$ | async;
 @let studentId = myGradesService.studentId$ | async;
 @let gradingScales = myGradesService.gradingScales$ | async;
 

--- a/src/app/my-grades/components/my-grades-show/my-grades-show.component.spec.ts
+++ b/src/app/my-grades/components/my-grades-show/my-grades-show.component.spec.ts
@@ -19,7 +19,7 @@ describe("MyGradesShowComponent", () => {
             useValue: {
               loading$: of(false),
               studentId$: of(1),
-              studentCoursesSorted$: of([]),
+              studentCourses$: of([]),
               gradingScales$: of([]),
             },
           },

--- a/src/app/my-grades/services/my-grades.service.ts
+++ b/src/app/my-grades/services/my-grades.service.ts
@@ -12,8 +12,7 @@ import {
   switchMap,
 } from "rxjs";
 import { EventScope } from "src/app/events/components/common/events-scope-select/events-scope-select.component";
-import { getCourseFilterParamsForScope } from "src/app/shared/utils/courses";
-import { spread } from "src/app/shared/utils/function";
+import { filterEventsForScope } from "src/app/shared/utils/courses";
 import { Course } from "../../shared/models/course.model";
 import { CoursesRestService } from "../../shared/services/courses-rest.service";
 import { GradingScalesRestService } from "../../shared/services/grading-scales-rest.service";
@@ -48,15 +47,14 @@ export class MyGradesService {
   private scopeSubject$ = new BehaviorSubject<EventScope>("current");
   scope$ = this.scopeSubject$.asObservable();
 
-  private studentCourses$ = combineLatest([this.eventIds$, this.scope$])
-    .pipe(switchMap(spread(this.loadCourses.bind(this))))
-    .pipe(shareReplay(1));
-  studentCoursesSorted$ = this.studentCourses$.pipe(
-    map((courses) =>
-      courses
-        .slice()
-        .sort((c1, c2) => c1.Designation.localeCompare(c2.Designation)),
+  studentCourses$ = this.eventIds$.pipe(
+    switchMap(this.loadCourses.bind(this)),
+    switchMap((courses) =>
+      this.scope$.pipe(
+        map((scope) => this.filterAndSortCourses(scope, courses)),
+      ),
     ),
+    shareReplay(1),
   );
 
   testReports$ = this.subscriptionIds$.pipe(
@@ -100,15 +98,20 @@ export class MyGradesService {
 
   private loadCourses(
     eventIds: ReadonlyArray<number>,
-    scope: EventScope,
   ): Observable<ReadonlyArray<Course>> {
     if (eventIds.length === 0) return of([]);
 
     return this.loadingService.load(
-      this.coursesRestService.getCoursesForMyGrades(
-        eventIds,
-        getCourseFilterParamsForScope(scope),
-      ),
+      this.coursesRestService.getCoursesForMyGrades(eventIds),
+    );
+  }
+
+  private filterAndSortCourses(
+    scope: EventScope,
+    courses: ReadonlyArray<Course>,
+  ): ReadonlyArray<Course> {
+    return [...filterEventsForScope(scope, courses)].sort((a, b) =>
+      a.Designation.localeCompare(b.Designation),
     );
   }
 

--- a/src/app/shared/services/courses-rest.service.ts
+++ b/src/app/shared/services/courses-rest.service.ts
@@ -117,7 +117,7 @@ export class CoursesRestService extends RestService<typeof Course> {
    */
   getCoursesForMyGrades(
     courseIds: ReadonlyArray<number>,
-    additionalParams: Record<string, string>,
+    additionalParams: Record<string, string> = {},
   ): Observable<ReadonlyArray<Course>> {
     const params = {
       ...additionalParams,

--- a/src/app/shared/services/student-grades.service.spec.ts
+++ b/src/app/shared/services/student-grades.service.spec.ts
@@ -101,10 +101,11 @@ describe("StudentGradesService", () => {
       expect(
         subscriptionsRestService.getSubscriptionsByStudent,
       ).toHaveBeenCalledWith(123);
-      expect(coursesRestService.getCoursesForDossier).toHaveBeenCalledWith(
-        [course1.Id, course2.Id, course3.Id],
-        { "filter.DateTo": ">2000-01-22" },
-      );
+      expect(coursesRestService.getCoursesForDossier).toHaveBeenCalledWith([
+        course1.Id,
+        course2.Id,
+        course3.Id,
+      ]);
     });
   });
 

--- a/src/app/shared/services/student-grades.service.ts
+++ b/src/app/shared/services/student-grades.service.ts
@@ -19,9 +19,8 @@ import { gradingScaleOfTest, resultOfStudent } from "../../events/utils/tests";
 import { Course, FinalGrading, Grading } from "../models/course.model";
 import { Grade, GradingScale } from "../models/grading-scale.model";
 import { Test } from "../models/test.model";
-import { getCourseFilterParamsForScope } from "../utils/courses";
+import { filterEventsForScope } from "../utils/courses";
 import { notNull } from "../utils/filter";
-import { spread } from "../utils/function";
 import { ValueWithWeight } from "../utils/math";
 import { CoursesRestService } from "./courses-rest.service";
 import { GradingScalesRestService } from "./grading-scales-rest.service";
@@ -34,7 +33,7 @@ const GRADES_CONTEXT = "studentDossierGrades";
 type CoursesAction =
   | {
       type: "initializeCourses";
-      payload: Course[];
+      payload: ReadonlyArray<Course>;
     }
   | {
       type: "updateCourses";
@@ -63,15 +62,12 @@ export class StudentGradesService {
   private scopeSubject$ = new BehaviorSubject<EventScope>("current");
   scope$ = this.scopeSubject$.asObservable();
 
-  private initialStudentCourses$ = combineLatest([
-    this.eventIds$,
-    this.scope$,
-  ]).pipe(
+  private initialStudentCourses$ = this.eventIds$.pipe(
     distinctUntilChanged(isEqual),
-    switchMap(spread(this.loadCourses.bind(this))),
-    map((courses) =>
-      [...courses].sort((c1, c2) =>
-        c1.Designation.localeCompare(c2.Designation),
+    switchMap(this.loadCourses.bind(this)),
+    switchMap((courses) =>
+      this.scope$.pipe(
+        map((scope) => this.filterAndSortCourses(scope, courses)),
       ),
     ),
     startWith([]),
@@ -165,15 +161,11 @@ export class StudentGradesService {
 
   private loadCourses(
     eventIds: ReadonlyArray<number>,
-    scope: EventScope,
   ): Observable<ReadonlyArray<Course>> {
     if (eventIds.length === 0) return of([]);
 
     return this.loadingService.load(
-      this.coursesRestService.getCoursesForDossier(
-        eventIds,
-        getCourseFilterParamsForScope(scope),
-      ),
+      this.coursesRestService.getCoursesForDossier(eventIds),
       { context: GRADES_CONTEXT },
     );
   }
@@ -216,6 +208,15 @@ export class StudentGradesService {
     switchMap((ids) => this.gradingScalesRestService.getListForIds(ids)),
     shareReplay(1),
   );
+
+  private filterAndSortCourses(
+    scope: EventScope,
+    courses: ReadonlyArray<Course>,
+  ): ReadonlyArray<Course> {
+    return [...filterEventsForScope(scope, courses)].sort((a, b) =>
+      a.Designation.localeCompare(b.Designation),
+    );
+  }
 
   private coursesReducer(
     state: ReadonlyArray<Course>,

--- a/src/app/shared/utils/courses.spec.ts
+++ b/src/app/shared/utils/courses.spec.ts
@@ -1,7 +1,16 @@
-import { getCourseFilterParamsForScope } from "./courses";
+import { filterEventsForScope } from "./courses";
 
 describe("courses utils", () => {
-  describe("getCourseFilterParamsForScope", () => {
+  describe("filterEventsForScope", () => {
+    const today = new Date("2000-01-23T00:00:00");
+    const yesterday = new Date("2000-01-22T00:00:00");
+    const tomorrow = new Date("2000-01-24T00:00:00");
+
+    const eventNoDate = { DateTo: null };
+    const eventYesterday = { DateTo: yesterday };
+    const eventToday = { DateTo: today };
+    const eventTomorrow = { DateTo: tomorrow };
+
     beforeEach(() => {
       jasmine.clock().install();
       jasmine.clock().mockDate(new Date("2000-01-23T12:00:00"));
@@ -11,15 +20,47 @@ describe("courses utils", () => {
       jasmine.clock().uninstall();
     });
 
-    it("returns a filter for dates before today when scope is 'past'", () => {
-      expect(getCourseFilterParamsForScope("past")).toEqual({
-        "filter.DateTo": "<2000-01-23",
+    describe("scope 'current'", () => {
+      it("includes events with no end date", () => {
+        expect(filterEventsForScope("current", [eventNoDate])).toEqual([
+          eventNoDate,
+        ]);
+      });
+
+      it("includes events ending today", () => {
+        expect(filterEventsForScope("current", [eventToday])).toEqual([
+          eventToday,
+        ]);
+      });
+
+      it("includes events ending in the future", () => {
+        expect(filterEventsForScope("current", [eventTomorrow])).toEqual([
+          eventTomorrow,
+        ]);
+      });
+
+      it("excludes events that ended before today", () => {
+        expect(filterEventsForScope("current", [eventYesterday])).toEqual([]);
       });
     });
 
-    it("returns a filter for dates after yesterday when scope is 'current'", () => {
-      expect(getCourseFilterParamsForScope("current")).toEqual({
-        "filter.DateTo": ">2000-01-22",
+    describe("scope 'past'", () => {
+      it("includes events that ended before today", () => {
+        expect(filterEventsForScope("past", [eventYesterday])).toEqual([
+          eventYesterday,
+        ]);
+      });
+
+      it("excludes events ending today", () => {
+        expect(filterEventsForScope("past", [eventToday])).toEqual([]);
+      });
+
+      it("excludes events ending in the future", () => {
+        expect(filterEventsForScope("past", [eventTomorrow])).toEqual([]);
+      });
+
+      it("excludes events with no end date", () => {
+        expect(filterEventsForScope("past", [eventNoDate])).toEqual([]);
       });
     });
   });

--- a/src/app/shared/utils/courses.ts
+++ b/src/app/shared/utils/courses.ts
@@ -1,16 +1,14 @@
-import { format, subDays } from "date-fns";
+import { startOfDay } from "date-fns";
 import { EventScope } from "src/app/events/components/common/events-scope-select/events-scope-select.component";
 
-export function getCourseFilterParamsForScope(
+export function filterEventsForScope<T extends { DateTo: Option<Date> }>(
   scope: EventScope,
-): Record<string, string> {
-  const today = new Date();
-  if (scope === "past") {
-    return {
-      "filter.DateTo": `<${format(today, "yyyy-MM-dd")}`,
-    };
-  }
-  return {
-    "filter.DateTo": `>${format(subDays(today, 1), "yyyy-MM-dd")}`,
-  };
+  events: ReadonlyArray<T>,
+): ReadonlyArray<T> {
+  const today = startOfDay(new Date());
+  return events.filter(
+    (event) =>
+      (scope === "current" && (!event.DateTo || event.DateTo >= today)) ||
+      (scope === "past" && event.DateTo && event.DateTo < today),
+  );
 }


### PR DESCRIPTION
#1068

- Aktuelle/Vergangene Anlässe werden neu Client-seitig statt Server-seitig gefilter
- Die Filterung berücksichtigt Anlässe mit `DateTo == null` als «Aktuelle Anlässe»