### PR TITLE
Fix visibility of instructor email edit links 

### DIFF
--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.html
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.html
@@ -42,7 +42,7 @@
   ></bkd-dashboard-action>
 }
 
-@if ((dashboardService.hasStudentRole$ | async) && canEditInstructorEmail()) {
+@if (canEditInstructorEmail()) {
   <bkd-dashboard-action
     [label]="'dashboard.actions.edit-instructor-email'"
     [link]="['/my-profile/edit-instructor-email']"

--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.spec.ts
@@ -74,6 +74,9 @@ describe("DashboardActionsComponent", () => {
               getMyself() {
                 return of(buildPerson(3));
               },
+              getInstructorEmail() {
+                return of("test@example.com");
+              },
             },
           },
           {

--- a/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.ts
+++ b/src/app/dashboard/components/dashboard-actions/dashboard-actions.component.ts
@@ -1,8 +1,15 @@
 import { AsyncPipe } from "@angular/common";
+import { HttpContext } from "@angular/common/http";
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { TranslatePipe } from "@ngx-translate/core";
+import { Observable, combineLatest, map, of, switchMap } from "rxjs";
+import { RestErrorInterceptorOptions } from "src/app/shared/interceptors/rest-error.interceptor";
 import { ConfigurationsService } from "src/app/shared/services/configurations.service";
+import { PersonsRestService } from "src/app/shared/services/persons-rest.service";
+import { StorageService } from "src/app/shared/services/storage.service";
+import { isEmail } from "src/app/shared/utils/email";
+import { catch404 } from "src/app/shared/utils/observable";
 import { SETTINGS, Settings } from "../../../settings";
 import { DashboardService } from "../../services/dashboard.service";
 import { DashboardActionComponent } from "../dashboard-action/dashboard-action.component";
@@ -24,15 +31,43 @@ export class DashboardActionsComponent {
   dashboardService = inject(DashboardService);
   settings = inject<Settings>(SETTINGS);
   private configurationsService = inject(ConfigurationsService);
+  private personsService = inject(PersonsRestService);
+  private storageService = inject(StorageService);
 
-  canEditInstructorEmail = toSignal(
-    this.configurationsService.canEditInstructorEmail$,
-    {
-      initialValue: false,
-    },
-  );
+  canEditInstructorEmail = toSignal(this.loadCanEditInstructorEmail(), {
+    initialValue: false,
+  });
 
   get substitutionsAdminLink(): string {
     return this.settings.dashboard.substitutionsAdminLink;
+  }
+
+  private loadCanEditInstructorEmail(): Observable<boolean> {
+    return this.dashboardService.hasStudentRole$.pipe(
+      switchMap((hasStudentRole) => {
+        if (!hasStudentRole) return of(false);
+
+        return combineLatest([
+          this.configurationsService.canEditInstructorEmail$,
+          this.loadInstructorEmailValue(),
+        ]).pipe(
+          map(([canEdit, value]) => canEdit && (!value || isEmail(value))),
+        );
+      }),
+    );
+  }
+
+  private loadInstructorEmailValue(): Observable<unknown> {
+    const studentId = this.storageService.getPayload()?.id_person;
+    return studentId
+      ? this.personsService
+          .getInstructorEmail(
+            Number(studentId),
+            new HttpContext().set(RestErrorInterceptorOptions, {
+              disableErrorHandlingForStatus: [404],
+            }),
+          )
+          .pipe(catch404())
+      : of(null);
   }
 }

--- a/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.html
+++ b/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.html
@@ -1,9 +1,28 @@
+@let trainer = apprenticeship()?.jobTrainer;
+
 <div class="bkd-container bkd-container-limited">
   @if (loading()) {
     <bkd-spinner></bkd-spinner>
   } @else {
     <h1>{{ "my-profile.edit-instructor-email.title" | translate }}</h1>
     <form (submit)="onSubmit($event)" novalidate>
+      <div class="mb-3">
+        @if (trainer) {
+          {{ "my-profile.edit-instructor-email.trainer-label" | translate
+          }}{{ ":" | addSpace: ":" }}
+          <address>
+            @if (trainer.Lastname || trainer.Firstname) {
+              {{ trainer.Lastname || "" }}
+              {{ trainer.Firstname || "" }}<br />
+            }
+            @if (trainer | bkdPersonEmail) {
+              <a href="mailto:{{ trainer | bkdPersonEmail }}">{{
+                trainer | bkdPersonEmail
+              }}</a>
+            }
+          </address>
+        }
+      </div>
       <p>{{ "my-profile.edit-instructor-email.description" | translate }}</p>
       <div class="mb-3">
         <label class="form-label" for="my-profile-email-instructor">

--- a/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.spec.ts
+++ b/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.spec.ts
@@ -69,7 +69,7 @@ describe("MyProfileEditInstructorEmailComponent", () => {
     expect(personsService.updateInstructorEmail).not.toHaveBeenCalled();
 
     changeValue("");
-    expect(element.querySelector(".invalid-feedback")).not.toBeNull();
+    expect(element.querySelector(".invalid-feedback")).toBeNull();
 
     changeValue("jane@example.com");
     expect(element.querySelector(".invalid-feedback")).toBeNull();

--- a/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.spec.ts
+++ b/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.spec.ts
@@ -3,7 +3,12 @@ import { Router } from "@angular/router";
 import { of } from "rxjs";
 import { PersonsRestService } from "src/app/shared/services/persons-rest.service";
 import { ToastService } from "src/app/shared/services/toast.service";
-import { buildPerson } from "src/spec-builders";
+import {
+  buildApprenticeshipContract,
+  buildApprenticeshipManager,
+  buildJobTrainer,
+  buildPerson,
+} from "src/spec-builders";
 import { buildTestModuleMetadata } from "src/spec-helpers";
 import { MyProfileService } from "../../services/my-profile.service";
 import { MyProfileEditInstructorEmailComponent } from "./my-profile-edit-instructor-email.component";
@@ -21,6 +26,13 @@ describe("MyProfileEditInstructorEmailComponent", () => {
 
     profileService = {
       person$: of(person),
+      apprenticeships$: of([
+        {
+          apprenticeshipContract: buildApprenticeshipContract(1),
+          jobTrainer: buildJobTrainer(1),
+          apprenticeshipManager: buildApprenticeshipManager(1),
+        },
+      ]),
       loadingPerson$: of(false),
       reloadStudent: jasmine.createSpy("reloadStudent"),
     } as unknown as MyProfileService;

--- a/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.ts
+++ b/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.ts
@@ -13,8 +13,10 @@ import { Observable, finalize, map, switchMap, take, throwError } from "rxjs";
 import { FormErrorsComponent } from "src/app/shared/components/form-errors/form-errors.component";
 import { SpinnerComponent } from "src/app/shared/components/spinner/spinner.component";
 import { SubmitButtonComponent } from "src/app/shared/components/submit-button/submit-button.component";
+import { PersonEmailPipe } from "src/app/shared/pipes/person-email.pipe";
 import { PersonsRestService } from "src/app/shared/services/persons-rest.service";
 import { ToastService } from "src/app/shared/services/toast.service";
+import { AddSpacePipe } from "../../../shared/pipes/add-space.pipe";
 import { MyProfileService } from "../../services/my-profile.service";
 
 type InstructorEmailFormData = {
@@ -29,6 +31,8 @@ type InstructorEmailFormData = {
     SubmitButtonComponent,
     FormErrorsComponent,
     SpinnerComponent,
+    PersonEmailPipe,
+    AddSpacePipe,
   ],
   templateUrl: "./my-profile-edit-instructor-email.component.html",
   styleUrl: "./my-profile-edit-instructor-email.component.scss",
@@ -51,6 +55,13 @@ export class MyProfileEditInstructorEmailComponent {
   instructorEmail = toSignal(this.loadInstructorEmail(), {
     initialValue: null,
   });
+
+  apprenticeship = toSignal(
+    this.profileService.apprenticeships$.pipe(map((v) => (v && v[0]) ?? null)),
+    {
+      initialValue: null,
+    },
+  );
 
   formData = linkedSignal<InstructorEmailFormData>(() => {
     return {

--- a/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.ts
+++ b/src/app/my-profile/components/my-profile-edit-instructor-email/my-profile-edit-instructor-email.component.ts
@@ -6,7 +6,7 @@ import {
   signal,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { FormField, email, form, required } from "@angular/forms/signals";
+import { FormField, email, form } from "@angular/forms/signals";
 import { ActivatedRoute, Router } from "@angular/router";
 import { TranslatePipe, TranslateService } from "@ngx-translate/core";
 import { Observable, finalize, map, switchMap, take, throwError } from "rxjs";
@@ -58,7 +58,6 @@ export class MyProfileEditInstructorEmailComponent {
     };
   });
   instructorEmailForm = form(this.formData, (schema) => {
-    required(schema.instructorEmail);
     email(schema.instructorEmail);
   });
 

--- a/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.html
+++ b/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.html
@@ -80,8 +80,8 @@
       {{ "shared.profile.instructor-email" | translate }}{{ ":" | addSpace: ":"
       }}<br />
       @let email = instructorEmail();
-      @if (email) {
-        <a href="mailto:{{ email }}">{{ email }}</a>
+      @if (email.value) {
+        <a href="mailto:{{ email.value }}">{{ email.value }}</a>
       } @else {
         –
       }
@@ -89,7 +89,7 @@
 
     @let editLink = instructorEmailEditLink();
     @let editLabel = instructorEmailEditLabel();
-    @if (email && editLink) {
+    @if (editLink && !email.hasNonEmailValue) {
       <a
         class="btn btn-primary btn-icon me-2"
         [routerLink]="editLink"

--- a/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.spec.ts
+++ b/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.spec.ts
@@ -44,9 +44,7 @@ describe("StudentContactApprenticeshipComponent", () => {
   describe("instructor email", () => {
     describe("email value", () => {
       it("renders email if present", () => {
-        student.Custom1 = "test@example.com";
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.detectChanges();
+        setCustom1("test@example.com");
 
         const link = getInstructorEmailSection().querySelector("a");
         expect(link).not.toBeNull();
@@ -54,9 +52,7 @@ describe("StudentContactApprenticeshipComponent", () => {
       });
 
       it("renders dash for non-email value", () => {
-        student.Custom1 = "Lorem ipsum dolor sit amet";
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.detectChanges();
+        setCustom1("Lorem ipsum dolor sit amet");
 
         const section = getInstructorEmailSection();
         expect(section.textContent).toContain("–");
@@ -64,9 +60,7 @@ describe("StudentContactApprenticeshipComponent", () => {
       });
 
       it("renders dash for null value", () => {
-        student.Custom1 = null;
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.detectChanges();
+        setCustom1(null);
 
         const section = getInstructorEmailSection();
         expect(section.textContent).toContain("–");
@@ -75,62 +69,70 @@ describe("StudentContactApprenticeshipComponent", () => {
     });
 
     describe("edit link", () => {
-      it("renders edit link if present and email is valid", () => {
-        student.Custom1 = "test@example.com";
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.componentRef.setInput(
-          "instructorEmailEditLink",
-          "/edit-instructor-email",
-        );
-        fixture.componentRef.setInput(
-          "instructorEmailEditLabel",
-          "Edit instructor email",
-        );
-        fixture.detectChanges();
+      describe("with instructorEmailEditLink and instructorEmailEditLabel", () => {
+        beforeEach(() => {
+          fixture.componentRef.setInput(
+            "instructorEmailEditLink",
+            "/edit-instructor-email",
+          );
+          fixture.componentRef.setInput(
+            "instructorEmailEditLabel",
+            "Edit instructor email",
+          );
+        });
 
-        const section = getInstructorEmailSection();
+        it("is rendered if present and value is valid email", () => {
+          setCustom1("test@example.com");
 
-        const editLink = section.querySelector(
-          "[aria-label='Edit instructor email']",
-        );
-        expect(editLink).not.toBeNull();
-        expect(editLink?.getAttribute("href")).toBe("/edit-instructor-email");
+          const editLink = getEditLink();
+          expect(editLink).not.toBeNull();
+          expect(editLink?.getAttribute("href")).toBe("/edit-instructor-email");
+        });
+
+        it("is rendered if present and value is empty string", () => {
+          setCustom1("");
+
+          const editLink = getEditLink();
+          expect(editLink).not.toBeNull();
+          expect(editLink?.getAttribute("href")).toBe("/edit-instructor-email");
+        });
+
+        it("is rendered if present and value is null", () => {
+          setCustom1(null);
+
+          const editLink = getEditLink();
+          expect(editLink).not.toBeNull();
+          expect(editLink?.getAttribute("href")).toBe("/edit-instructor-email");
+        });
+
+        it("is not rendered if present and value is not a valid email", () => {
+          setCustom1("Lorem ipsum dolor sit amet");
+
+          expect(getEditLink()).toBeNull();
+        });
       });
 
-      it("does not render edit link if present and email is invalid", () => {
-        student.Custom1 = "Lorem ipsum dolor sit amet";
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.componentRef.setInput(
-          "instructorEmailEditLink",
-          "/edit-instructor-email",
-        );
-        fixture.componentRef.setInput(
-          "instructorEmailEditLabel",
-          "Edit instructor email",
-        );
-        fixture.detectChanges();
-
-        const section = getInstructorEmailSection();
-
-        const editLink = section.querySelector(
-          "[aria-label='Edit instructor email']",
-        );
-        expect(editLink).toBeNull();
-      });
-
-      it("does not render edit link if absent and email is valid", () => {
-        student.Custom1 = "test@example.com";
-        fixture.componentRef.setInput("student", { ...student });
-        fixture.detectChanges();
-
-        const section = getInstructorEmailSection();
-
-        const editLink = section.querySelector(
-          "[aria-label='Edit instructor email']",
-        );
-        expect(editLink).toBeNull();
+      describe("without instructorEmailEditLink and instructorEmailEditLabel", () => {
+        it("is not rendered if value is valid email", () => {
+          setCustom1("test@example.com");
+          expect(getEditLink()).toBeNull();
+        });
       });
     });
+
+    function setCustom1(value: unknown) {
+      student.Custom1 = value;
+      fixture.componentRef.setInput("student", { ...student });
+      fixture.detectChanges();
+    }
+
+    function getEditLink() {
+      const section = getInstructorEmailSection();
+      const editLink = section.querySelector(
+        "[aria-label='Edit instructor email']",
+      );
+      return editLink;
+    }
 
     function getInstructorEmailSection(): HTMLDivElement {
       const section = Array.from(element.querySelectorAll("div")).find((div) =>

--- a/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.ts
+++ b/src/app/shared/components/student/student-contact-apprenticeship/student-contact-apprenticeship.component.ts
@@ -5,10 +5,10 @@ import {
   computed,
   input,
 } from "@angular/core";
-import { FormControl, Validators } from "@angular/forms";
 import { RouterLink } from "@angular/router";
 import { TranslatePipe } from "@ngx-translate/core";
 import { Person } from "src/app/shared/models/person.model";
+import { isEmail } from "src/app/shared/utils/email";
 import { AddSpacePipe } from "../../../pipes/add-space.pipe";
 import { PersonEmailPipe } from "../../../pipes/person-email.pipe";
 import { Apprenticeship } from "../../../services/student-profile.service";
@@ -28,18 +28,12 @@ export class StudentContactApprenticeshipComponent {
 
   instructorEmail = computed(() => {
     const value = this.student().Custom1;
-    return this.isEmail(value) ? value : null;
+    const valid = isEmail(value);
+    return {
+      value: valid ? value : null,
+      hasNonEmailValue: value && !valid,
+    };
   });
 
   constructor() {}
-
-  private isEmail(value: unknown): value is string {
-    if (typeof value !== "string") {
-      return false;
-    }
-
-    // Instead of implementing a custom email validation, reuse Angular's logic
-    // from the form validator
-    return Validators.email(new FormControl(value)) === null;
-  }
 }

--- a/src/app/shared/services/persons-rest.service.ts
+++ b/src/app/shared/services/persons-rest.service.ts
@@ -128,6 +128,21 @@ export class PersonsRestService extends RestService<typeof Person> {
       .pipe(map(() => undefined));
   }
 
+  getInstructorEmail(
+    personId: number,
+    context?: HttpContext,
+  ): Observable<unknown> {
+    return this.http
+      .get<unknown>(`${this.baseUrl}/`, {
+        context,
+        params: { "filter.Id": `=${personId}`, fields: "Custom1" },
+      })
+      .pipe(
+        switchMap(decode(t.array(t.type(pick(this.codec.props, ["Custom1"]))))),
+        map((persons) => persons[0]?.Custom1 ?? null),
+      );
+  }
+
   updateInstructorEmail(
     personId: number,
     instructorEmail: string,

--- a/src/app/shared/utils/email.spec.ts
+++ b/src/app/shared/utils/email.spec.ts
@@ -1,0 +1,33 @@
+import { isEmail } from "./email";
+
+describe("email utils", () => {
+  describe("isEmail", () => {
+    it("returns true for a valid email", () => {
+      expect(isEmail("john.doe@example.com")).toBe(true);
+    });
+
+    it("returns true for an email without a TLD", () => {
+      expect(isEmail("foo@localhost")).toBe(true);
+    });
+
+    it("returns false for 'Lorem ipsum dolor sit amet'", () => {
+      expect(isEmail("Lorem ipsum dolor sit amet")).toBe(false);
+    });
+
+    it("returns false for 'foobar'", () => {
+      expect(isEmail("foobar")).toBe(false);
+    });
+
+    it("returns false for ''", () => {
+      expect(isEmail("")).toBe(false);
+    });
+
+    it("returns false for null", () => {
+      expect(isEmail(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isEmail(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/app/shared/utils/email.ts
+++ b/src/app/shared/utils/email.ts
@@ -1,0 +1,12 @@
+import { FormControl, Validators } from "@angular/forms";
+
+export function isEmail(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  if (value === "") return false;
+
+  // Instead of implementing a custom email validation, reuse Angular's logic
+  // from the form validator
+  return Validators.email(new FormControl(value)) === null;
+}

--- a/src/assets/locales/de-CH.json
+++ b/src/assets/locales/de-CH.json
@@ -620,7 +620,8 @@
     },
     "edit-instructor-email": {
       "title": "E-Mail Praxisbildner/in bearbeiten",
-      "description": "Ist eine E-Mail-Adresse erfasst, erhält diese Person die Benachrichtigungen zu Ihren Absenzen.",
+      "description": "Falls in Ihrem Lehrbetrieb eine andere Person über Ihre Absenzen informiert werden soll, erfassen Sie bitte deren E-Mail-Adresse.",
+      "trainer-label": "Berufsbildner/in",
       "field-label": "E-Mail Praxisbildner/in",
       "field-hint": "Achtung: Beim Speichern wird eine Information an Praxis- und Berufsbildner/in geschickt.",
       "cancel": "Abbrechen",

--- a/src/assets/locales/fr-CH.json
+++ b/src/assets/locales/fr-CH.json
@@ -620,7 +620,8 @@
     },
     "edit-instructor-email": {
       "title": "Modifier e-mail formateur-trice pratique",
-      "description": "Si une adresse électronique est saisie, cette personne recevra les notifications relatives à vos absences.",
+      "description": "Si, dans votre entreprise formatrice, une autre personne doit être informée de vos absences, veuillez indiquer son adresse électronique.",
+      "trainer-label": "Formateur/trice",
       "field-label": "E-mail formateur-trice pratique",
       "field-hint": "Attention : Lors de l'enregistrement, une information est envoyée à la personne qui est formateur-trice pratique et formateur-trice.",
       "cancel": "Annuler",


### PR DESCRIPTION
#1020

- [x] E-Mail soll wieder bearbeitet können, wenn der Wert leer ist
- [x] Auf dem Dashboard soll die Bearbeiten-Action auch nur angezeigt werden, wenn der Wert leer ist oder eine gültige E-Mail. Wenn es ein anderer Wert ist soll sie ausgeblendet werden.
- [x] Anzeige der Berufsbildneradresse oberhalb des E-Mailfeldes.