### PR TITLE
Fix cropping in presence control & course students lists 

### DIFF
--- a/src/app/events/components/students/events-students-course-list/events-students-course-list.component.scss
+++ b/src/app/events/components/students/events-students-course-list/events-students-course-list.component.scss
@@ -9,7 +9,7 @@ section.list {
   width: calc(100% + 1px); // Hide right border
   margin-top: 1 * $spacer;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 400px), 1fr));
 }
 
 bkd-events-students-course-entry {

--- a/src/app/presence-control/components/presence-control-entry/presence-control-entry.component.scss
+++ b/src/app/presence-control/components/presence-control-entry/presence-control-entry.component.scss
@@ -8,7 +8,7 @@
     "avatar status designation previously-absent"
     "avatar student-info student-info student-info"
     "avatar incident incident incident";
-  grid-template-columns: min-content min-content 3fr min-content;
+  grid-template-columns: min-content min-content 1fr min-content;
 }
 
 :host > * {

--- a/src/app/presence-control/components/presence-control-list/presence-control-list.component.scss
+++ b/src/app/presence-control/components/presence-control-list/presence-control-list.component.scss
@@ -13,7 +13,7 @@ bkd-presence-control-entry {
   display: grid;
   grid-template-columns: repeat(
     auto-fill,
-    minmax($bkd-presence-control-entry-min-width, 1fr)
+    minmax(min(100%, $bkd-presence-control-entry-min-width), 1fr)
   );
 
   > * {


### PR DESCRIPTION
#1098

Das Problem trat an zwei Orten auf, wenn die Bildschirmbreite schmaler als die minimalen 400px der Grid-Element war:

- http://localhost:4200/#/presence-control?date=2026-06-29&viewMode=grid&lesson=3387
- http://localhost:4200/#/events/current/9716?returnlink=%252Fevents%252Fcurrent 

Das Element konnte dann nicht schmaler als 400px werden und hat overflowed. Mit `min(100%, 400px)` kann dies gefixt werden.